### PR TITLE
Ensure we're operating on relative paths vs. absolute

### DIFF
--- a/__tests__/__fixtures__/ember-template-lint-no-results.json
+++ b/__tests__/__fixtures__/ember-template-lint-no-results.json
@@ -4,37 +4,37 @@
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/search.hbs",
+      "filePath": "{{path}}/app/templates/search.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/settings.hbs",
+      "filePath": "{{path}}/app/templates/settings.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/signin.hbs",
+      "filePath": "{{path}}/app/templates/signin.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/travisci-vs-jenkins/index.hbs",
+      "filePath": "{{path}}/app/templates/travisci-vs-jenkins/index.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/travisci-vs-jenkins/thank-you.hbs",
+      "filePath": "{{path}}/app/templates/travisci-vs-jenkins/thank-you.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/unsubscribe.hbs",
+      "filePath": "{{path}}/app/templates/unsubscribe.hbs",
       "source": ""
     }
   ]

--- a/__tests__/__fixtures__/ember-template-lint-with-errors.json
+++ b/__tests__/__fixtures__/ember-template-lint-with-errors.json
@@ -6,7 +6,7 @@
         {
           "rule": "require-input-label",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/add-ssh-key.hbs",
+          "moduleId": "{{path}}/app/templates/components/add-ssh-key.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 3,
           "column": 4,
@@ -15,7 +15,7 @@
         {
           "rule": "require-input-label",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/add-ssh-key.hbs",
+          "moduleId": "{{path}}/app/templates/components/add-ssh-key.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 27,
           "column": 8,
@@ -23,7 +23,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/add-ssh-key.hbs",
+      "filePath": "{{path}}/app/templates/components/add-ssh-key.hbs",
       "source": ""
     },
     {
@@ -31,7 +31,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/billing-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/billing-details.hbs",
           "message": "a tags must have an href attribute",
           "line": 96,
           "column": 14,
@@ -40,7 +40,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/billing-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/billing-details.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 96,
           "column": 64,
@@ -48,7 +48,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/billing/billing-details.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/billing-details.hbs",
       "source": ""
     },
     {
@@ -56,7 +56,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/contact-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/contact-details.hbs",
           "message": "a tags must have an href attribute",
           "line": 76,
           "column": 14,
@@ -65,7 +65,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/contact-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/contact-details.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 77,
           "column": 16,
@@ -73,13 +73,13 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/billing/contact-details.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/contact-details.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/components/billing/education.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/education.hbs",
       "source": ""
     },
     {
@@ -87,7 +87,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/payment-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/payment-details.hbs",
           "message": "a tags must have an href attribute",
           "line": 22,
           "column": 16,
@@ -96,7 +96,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/payment-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/payment-details.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 22,
           "column": 19,
@@ -104,7 +104,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/billing/payment-details.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/payment-details.hbs",
       "source": ""
     },
     {
@@ -112,7 +112,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/select-plan.hbs",
           "message": "a tags must have an href attribute",
           "line": 71,
           "column": 12,
@@ -121,7 +121,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/select-plan.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 42,
           "column": 14,
@@ -130,7 +130,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/select-plan.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 72,
           "column": 14,
@@ -138,7 +138,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/select-plan.hbs",
       "source": ""
     },
     {
@@ -146,7 +146,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/caches-item.hbs",
+          "moduleId": "{{path}}/app/templates/components/caches-item.hbs",
           "message": "a tags must have an href attribute",
           "line": 20,
           "column": 2,
@@ -155,7 +155,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/caches-item.hbs",
+          "moduleId": "{{path}}/app/templates/components/caches-item.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 23,
           "column": 4,
@@ -164,7 +164,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/caches-item.hbs",
+          "moduleId": "{{path}}/app/templates/components/caches-item.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 20,
           "column": 2,
@@ -172,7 +172,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/caches-item.hbs",
+      "filePath": "{{path}}/app/templates/components/caches-item.hbs",
       "source": ""
     },
     {
@@ -180,7 +180,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/dashboard-row.hbs",
+          "moduleId": "{{path}}/app/templates/components/dashboard-row.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 48,
           "column": 12,
@@ -189,7 +189,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/dashboard-row.hbs",
+          "moduleId": "{{path}}/app/templates/components/dashboard-row.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 74,
           "column": 12,
@@ -198,7 +198,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/dashboard-row.hbs",
+          "moduleId": "{{path}}/app/templates/components/dashboard-row.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 146,
           "column": 20,
@@ -206,7 +206,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/dashboard-row.hbs",
+      "filePath": "{{path}}/app/templates/components/dashboard-row.hbs",
       "source": ""
     },
     {
@@ -214,7 +214,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+          "moduleId": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
           "message": "a tags must have an href attribute",
           "line": 45,
           "column": 12,
@@ -223,7 +223,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+          "moduleId": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 19,
           "column": 51,
@@ -232,7 +232,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+          "moduleId": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 45,
           "column": 28,
@@ -240,7 +240,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+      "filePath": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
       "source": ""
     },
     {
@@ -248,7 +248,7 @@
         {
           "rule": "require-input-label",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/env-var.hbs",
+          "moduleId": "{{path}}/app/templates/components/env-var.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 8,
           "column": 2,
@@ -256,7 +256,7 @@
         }
       ],
       "errorCount": 1,
-      "filePath": "/Users/fake/app/templates/components/env-var.hbs",
+      "filePath": "{{path}}/app/templates/components/env-var.hbs",
       "source": ""
     },
     {
@@ -264,7 +264,7 @@
         {
           "rule": "require-input-label",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/forms/form-checkbox.hbs",
+          "moduleId": "{{path}}/app/templates/components/forms/form-checkbox.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 2,
           "column": 2,
@@ -272,7 +272,7 @@
         }
       ],
       "errorCount": 1,
-      "filePath": "/Users/fake/app/templates/components/forms/form-checkbox.hbs",
+      "filePath": "{{path}}/app/templates/components/forms/form-checkbox.hbs",
       "source": ""
     },
     {
@@ -280,7 +280,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/forms/form-field.hbs",
+          "moduleId": "{{path}}/app/templates/components/forms/form-field.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 108,
           "column": 34,
@@ -288,7 +288,7 @@
         }
       ],
       "errorCount": 1,
-      "filePath": "/Users/fake/app/templates/components/forms/form-field.hbs",
+      "filePath": "{{path}}/app/templates/components/forms/form-field.hbs",
       "source": ""
     },
     {
@@ -296,7 +296,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/github-apps-repository.hbs",
+          "moduleId": "{{path}}/app/templates/components/github-apps-repository.hbs",
           "message": "a tags must have an href attribute",
           "line": 21,
           "column": 2,
@@ -305,7 +305,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/github-apps-repository.hbs",
+          "moduleId": "{{path}}/app/templates/components/github-apps-repository.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 11,
           "column": 2,
@@ -313,7 +313,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/github-apps-repository.hbs",
+      "filePath": "{{path}}/app/templates/components/github-apps-repository.hbs",
       "source": ""
     },
     {
@@ -321,7 +321,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 124,
           "column": 8,
@@ -330,7 +330,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 130,
           "column": 10,
@@ -339,7 +339,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 136,
           "column": 12,
@@ -348,7 +348,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 143,
           "column": 12,
@@ -357,7 +357,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 124,
           "column": 58,
@@ -366,7 +366,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 130,
           "column": 73,
@@ -375,7 +375,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 136,
           "column": 77,
@@ -384,7 +384,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 143,
           "column": 78,
@@ -393,7 +393,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 124,
           "column": 8,
@@ -402,7 +402,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 130,
           "column": 10,
@@ -411,7 +411,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 136,
           "column": 12,
@@ -420,7 +420,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 143,
           "column": 12,
@@ -429,7 +429,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 231,
           "column": 10,
@@ -438,7 +438,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 2,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 242,
           "column": 10,
@@ -446,43 +446,43 @@
         }
       ],
       "errorCount": 14,
-      "filePath": "/Users/fake/app/templates/components/header-links.hbs",
+      "filePath": "{{path}}/app/templates/components/header-links.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/search.hbs",
+      "filePath": "{{path}}/app/templates/search.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/settings.hbs",
+      "filePath": "{{path}}/app/templates/settings.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/signin.hbs",
+      "filePath": "{{path}}/app/templates/signin.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/travisci-vs-jenkins/index.hbs",
+      "filePath": "{{path}}/app/templates/travisci-vs-jenkins/index.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/travisci-vs-jenkins/thank-you.hbs",
+      "filePath": "{{path}}/app/templates/travisci-vs-jenkins/thank-you.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/unsubscribe.hbs",
+      "filePath": "{{path}}/app/templates/unsubscribe.hbs",
       "source": ""
     }
   ]

--- a/__tests__/__fixtures__/ember-template-lint-with-warnings.json
+++ b/__tests__/__fixtures__/ember-template-lint-with-warnings.json
@@ -6,7 +6,7 @@
         {
           "rule": "require-input-label",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/add-ssh-key.hbs",
+          "moduleId": "{{path}}/app/templates/components/add-ssh-key.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 3,
           "column": 4,
@@ -15,7 +15,7 @@
         {
           "rule": "require-input-label",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/add-ssh-key.hbs",
+          "moduleId": "{{path}}/app/templates/components/add-ssh-key.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 27,
           "column": 8,
@@ -23,7 +23,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/add-ssh-key.hbs",
+      "filePath": "{{path}}/app/templates/components/add-ssh-key.hbs",
       "source": ""
     },
     {
@@ -31,7 +31,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/billing-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/billing-details.hbs",
           "message": "a tags must have an href attribute",
           "line": 96,
           "column": 14,
@@ -40,7 +40,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/billing-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/billing-details.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 96,
           "column": 64,
@@ -48,7 +48,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/billing/billing-details.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/billing-details.hbs",
       "source": ""
     },
     {
@@ -56,7 +56,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/contact-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/contact-details.hbs",
           "message": "a tags must have an href attribute",
           "line": 76,
           "column": 14,
@@ -65,7 +65,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/contact-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/contact-details.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 77,
           "column": 16,
@@ -73,13 +73,13 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/billing/contact-details.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/contact-details.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/components/billing/education.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/education.hbs",
       "source": ""
     },
     {
@@ -87,7 +87,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/payment-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/payment-details.hbs",
           "message": "a tags must have an href attribute",
           "line": 22,
           "column": 16,
@@ -96,7 +96,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/payment-details.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/payment-details.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 22,
           "column": 19,
@@ -104,7 +104,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/billing/payment-details.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/payment-details.hbs",
       "source": ""
     },
     {
@@ -112,7 +112,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/select-plan.hbs",
           "message": "a tags must have an href attribute",
           "line": 71,
           "column": 12,
@@ -121,7 +121,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/select-plan.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 42,
           "column": 14,
@@ -130,7 +130,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+          "moduleId": "{{path}}/app/templates/components/billing/select-plan.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 72,
           "column": 14,
@@ -138,7 +138,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/billing/select-plan.hbs",
+      "filePath": "{{path}}/app/templates/components/billing/select-plan.hbs",
       "source": ""
     },
     {
@@ -146,7 +146,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/caches-item.hbs",
+          "moduleId": "{{path}}/app/templates/components/caches-item.hbs",
           "message": "a tags must have an href attribute",
           "line": 20,
           "column": 2,
@@ -155,7 +155,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/caches-item.hbs",
+          "moduleId": "{{path}}/app/templates/components/caches-item.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 23,
           "column": 4,
@@ -164,7 +164,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/caches-item.hbs",
+          "moduleId": "{{path}}/app/templates/components/caches-item.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 20,
           "column": 2,
@@ -172,7 +172,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/caches-item.hbs",
+      "filePath": "{{path}}/app/templates/components/caches-item.hbs",
       "source": ""
     },
     {
@@ -180,7 +180,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/dashboard-row.hbs",
+          "moduleId": "{{path}}/app/templates/components/dashboard-row.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 48,
           "column": 12,
@@ -189,7 +189,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/dashboard-row.hbs",
+          "moduleId": "{{path}}/app/templates/components/dashboard-row.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 74,
           "column": 12,
@@ -198,7 +198,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/dashboard-row.hbs",
+          "moduleId": "{{path}}/app/templates/components/dashboard-row.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 146,
           "column": 20,
@@ -206,7 +206,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/dashboard-row.hbs",
+      "filePath": "{{path}}/app/templates/components/dashboard-row.hbs",
       "source": ""
     },
     {
@@ -214,7 +214,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+          "moduleId": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
           "message": "a tags must have an href attribute",
           "line": 45,
           "column": 12,
@@ -223,7 +223,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+          "moduleId": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 19,
           "column": 51,
@@ -232,7 +232,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+          "moduleId": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 45,
           "column": 28,
@@ -240,7 +240,7 @@
         }
       ],
       "errorCount": 3,
-      "filePath": "/Users/fake/app/templates/components/dialogs/cancel-subscription-modal.hbs",
+      "filePath": "{{path}}/app/templates/components/dialogs/cancel-subscription-modal.hbs",
       "source": ""
     },
     {
@@ -248,7 +248,7 @@
         {
           "rule": "require-input-label",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/env-var.hbs",
+          "moduleId": "{{path}}/app/templates/components/env-var.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 8,
           "column": 2,
@@ -256,7 +256,7 @@
         }
       ],
       "errorCount": 1,
-      "filePath": "/Users/fake/app/templates/components/env-var.hbs",
+      "filePath": "{{path}}/app/templates/components/env-var.hbs",
       "source": ""
     },
     {
@@ -264,7 +264,7 @@
         {
           "rule": "require-input-label",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/forms/form-checkbox.hbs",
+          "moduleId": "{{path}}/app/templates/components/forms/form-checkbox.hbs",
           "message": "Input elements require a valid associated label.",
           "line": 2,
           "column": 2,
@@ -272,7 +272,7 @@
         }
       ],
       "errorCount": 1,
-      "filePath": "/Users/fake/app/templates/components/forms/form-checkbox.hbs",
+      "filePath": "{{path}}/app/templates/components/forms/form-checkbox.hbs",
       "source": ""
     },
     {
@@ -280,7 +280,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/forms/form-field.hbs",
+          "moduleId": "{{path}}/app/templates/components/forms/form-field.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 108,
           "column": 34,
@@ -288,7 +288,7 @@
         }
       ],
       "errorCount": 1,
-      "filePath": "/Users/fake/app/templates/components/forms/form-field.hbs",
+      "filePath": "{{path}}/app/templates/components/forms/form-field.hbs",
       "source": ""
     },
     {
@@ -296,7 +296,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/github-apps-repository.hbs",
+          "moduleId": "{{path}}/app/templates/components/github-apps-repository.hbs",
           "message": "a tags must have an href attribute",
           "line": 21,
           "column": 2,
@@ -305,7 +305,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/github-apps-repository.hbs",
+          "moduleId": "{{path}}/app/templates/components/github-apps-repository.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 11,
           "column": 2,
@@ -313,7 +313,7 @@
         }
       ],
       "errorCount": 2,
-      "filePath": "/Users/fake/app/templates/components/github-apps-repository.hbs",
+      "filePath": "{{path}}/app/templates/components/github-apps-repository.hbs",
       "source": ""
     },
     {
@@ -321,7 +321,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 124,
           "column": 8,
@@ -330,7 +330,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 130,
           "column": 10,
@@ -339,7 +339,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 136,
           "column": 12,
@@ -348,7 +348,7 @@
         {
           "rule": "link-href-attributes",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "a tags must have an href attribute",
           "line": 143,
           "column": 12,
@@ -357,7 +357,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 124,
           "column": 58,
@@ -366,7 +366,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 130,
           "column": 73,
@@ -375,7 +375,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 136,
           "column": 77,
@@ -384,7 +384,7 @@
         {
           "rule": "no-invalid-interactive",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Interaction added to non-interactive element",
           "line": 143,
           "column": 78,
@@ -393,7 +393,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 124,
           "column": 8,
@@ -402,7 +402,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 130,
           "column": 10,
@@ -411,7 +411,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 136,
           "column": 12,
@@ -420,7 +420,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 143,
           "column": 12,
@@ -429,7 +429,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 231,
           "column": 10,
@@ -438,7 +438,7 @@
         {
           "rule": "no-invalid-link-title",
           "severity": 1,
-          "moduleId": "/Users/fake/app/templates/components/header-links.hbs",
+          "moduleId": "{{path}}/app/templates/components/header-links.hbs",
           "message": "Title attribute values should not be the same as the link text.",
           "line": 242,
           "column": 10,
@@ -446,43 +446,43 @@
         }
       ],
       "errorCount": 14,
-      "filePath": "/Users/fake/app/templates/components/header-links.hbs",
+      "filePath": "{{path}}/app/templates/components/header-links.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/search.hbs",
+      "filePath": "{{path}}/app/templates/search.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/settings.hbs",
+      "filePath": "{{path}}/app/templates/settings.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/signin.hbs",
+      "filePath": "{{path}}/app/templates/signin.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/travisci-vs-jenkins/index.hbs",
+      "filePath": "{{path}}/app/templates/travisci-vs-jenkins/index.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/travisci-vs-jenkins/thank-you.hbs",
+      "filePath": "{{path}}/app/templates/travisci-vs-jenkins/thank-you.hbs",
       "source": ""
     },
     {
       "messages": [],
       "errorCount": 0,
-      "filePath": "/Users/fake/app/templates/unsubscribe.hbs",
+      "filePath": "{{path}}/app/templates/unsubscribe.hbs",
       "source": ""
     }
   ]

--- a/__tests__/__fixtures__/eslint-no-results.json
+++ b/__tests__/__fixtures__/eslint-no-results.json
@@ -1,7 +1,7 @@
 {
   "results": [
     {
-      "filePath": "/Users/fake/tests/unit/utils/job-config-language-test.js",
+      "filePath": "{{path}}/tests/unit/utils/job-config-language-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -9,7 +9,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/paginated-collection-test.js",
+      "filePath": "{{path}}/tests/unit/utils/paginated-collection-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -17,7 +17,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/time-in-words-test.js",
+      "filePath": "{{path}}/tests/unit/utils/time-in-words-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -25,7 +25,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/ui-kit/assertions-test.js",
+      "filePath": "{{path}}/tests/unit/utils/ui-kit/assertions-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -33,7 +33,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/ui-kit/responsive-test.js",
+      "filePath": "{{path}}/tests/unit/utils/ui-kit/responsive-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -41,7 +41,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/vcs-test.js",
+      "filePath": "{{path}}/tests/unit/utils/vcs-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,

--- a/__tests__/__fixtures__/eslint-with-errors.json
+++ b/__tests__/__fixtures__/eslint-with-errors.json
@@ -1,7 +1,7 @@
 {
   "results": [
     {
-      "filePath": "/Users/fake/app/controllers/settings.js",
+      "filePath": "{{path}}/app/controllers/settings.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -44,7 +44,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/initializers/tracer.js",
+      "filePath": "{{path}}/app/initializers/tracer.js",
       "messages": [
         {
           "ruleId": "no-redeclare",
@@ -76,7 +76,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/models/build.js",
+      "filePath": "{{path}}/app/models/build.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -108,7 +108,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/services/insights.js",
+      "filePath": "{{path}}/app/services/insights.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -162,7 +162,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/utils/traverse-payload.js",
+      "filePath": "{{path}}/app/utils/traverse-payload.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -183,7 +183,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/tests/unit/services/insights-test.js",
+      "filePath": "{{path}}/tests/unit/services/insights-test.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -259,7 +259,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/job-config-language-test.js",
+      "filePath": "{{path}}/tests/unit/utils/job-config-language-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -267,7 +267,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/paginated-collection-test.js",
+      "filePath": "{{path}}/tests/unit/utils/paginated-collection-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -275,7 +275,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/time-in-words-test.js",
+      "filePath": "{{path}}/tests/unit/utils/time-in-words-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -283,7 +283,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/ui-kit/assertions-test.js",
+      "filePath": "{{path}}/tests/unit/utils/ui-kit/assertions-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -291,7 +291,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/ui-kit/responsive-test.js",
+      "filePath": "{{path}}/tests/unit/utils/ui-kit/responsive-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -299,7 +299,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/vcs-test.js",
+      "filePath": "{{path}}/tests/unit/utils/vcs-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,

--- a/__tests__/__fixtures__/eslint-with-warnings.json
+++ b/__tests__/__fixtures__/eslint-with-warnings.json
@@ -1,7 +1,7 @@
 {
   "results": [
     {
-      "filePath": "/Users/fake/app/controllers/settings.js",
+      "filePath": "{{path}}/app/controllers/settings.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -44,7 +44,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/initializers/tracer.js",
+      "filePath": "{{path}}/app/initializers/tracer.js",
       "messages": [
         {
           "ruleId": "no-redeclare",
@@ -76,7 +76,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/models/build.js",
+      "filePath": "{{path}}/app/models/build.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -108,7 +108,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/services/insights.js",
+      "filePath": "{{path}}/app/services/insights.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -162,7 +162,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/app/utils/traverse-payload.js",
+      "filePath": "{{path}}/app/utils/traverse-payload.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -183,7 +183,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/tests/unit/services/insights-test.js",
+      "filePath": "{{path}}/tests/unit/services/insights-test.js",
       "messages": [
         {
           "ruleId": "no-prototype-builtins",
@@ -259,7 +259,7 @@
       "source": ""
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/job-config-language-test.js",
+      "filePath": "{{path}}/tests/unit/utils/job-config-language-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -267,7 +267,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/paginated-collection-test.js",
+      "filePath": "{{path}}/tests/unit/utils/paginated-collection-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -275,7 +275,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/time-in-words-test.js",
+      "filePath": "{{path}}/tests/unit/utils/time-in-words-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -283,7 +283,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/ui-kit/assertions-test.js",
+      "filePath": "{{path}}/tests/unit/utils/ui-kit/assertions-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -291,7 +291,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/ui-kit/responsive-test.js",
+      "filePath": "{{path}}/tests/unit/utils/ui-kit/responsive-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,
@@ -299,7 +299,7 @@
       "fixableWarningCount": 0
     },
     {
-      "filePath": "/Users/fake/tests/unit/utils/vcs-test.js",
+      "filePath": "{{path}}/tests/unit/utils/vcs-test.js",
       "messages": [],
       "errorCount": 0,
       "warningCount": 0,

--- a/__tests__/__fixtures__/existing-batches.json
+++ b/__tests__/__fixtures__/existing-batches.json
@@ -1,0 +1,68 @@
+[
+  {
+    "filePath": "{{path}}/app/initializers/tracer.js",
+    "messages": [
+      {
+        "ruleId": "no-redeclare",
+        "severity": 2,
+        "message": "'window' is already defined as a built-in global variable.",
+        "line": 1,
+        "column": 11,
+        "nodeType": "Block",
+        "messageId": "redeclaredAsBuiltin",
+        "endLine": 1,
+        "endColumn": 17
+      },
+      {
+        "ruleId": "no-redeclare",
+        "severity": 2,
+        "message": "'XMLHttpRequest' is already defined as a built-in global variable.",
+        "line": 1,
+        "column": 19,
+        "nodeType": "Block",
+        "messageId": "redeclaredAsBuiltin",
+        "endLine": 1,
+        "endColumn": 33
+      }
+    ],
+    "errorCount": 2,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "",
+    "usedDeprecatedRules": []
+  },
+  {
+    "filePath": "{{path}}/app/models/build.js",
+    "messages": [
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 108,
+        "column": 50,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 108,
+        "endColumn": 64
+      },
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 120,
+        "column": 25,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 120,
+        "endColumn": 39
+      }
+    ],
+    "errorCount": 2,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "",
+    "usedDeprecatedRules": []
+  }
+]

--- a/__tests__/__fixtures__/fixtures.ts
+++ b/__tests__/__fixtures__/fixtures.ts
@@ -10,6 +10,8 @@ import * as emberTemplateLintNoResults from './ember-template-lint-no-results.js
 import * as singleFileTodo from './single-file-todo.json';
 import * as singleFileNoErrors from './single-file-no-errors.json';
 import * as singleFileTodoUpdated from './single-file-todo-updated.json';
+import * as newBatches from './new-batches.json';
+import * as existingBatches from './existing-batches.json';
 import { updatePaths } from '../__utils__';
 
 const fixtures = {
@@ -34,6 +36,8 @@ const fixtures = {
   singleFileTodo: <ESLint.LintResult[]>singleFileTodo,
   singleFileNoErrors: <ESLint.LintResult[]>singleFileNoErrors,
   singleFileTodoUpdated: <ESLint.LintResult[]>singleFileTodoUpdated,
+  newBatches: <ESLint.LintResult[]>newBatches,
+  existingBatches: <ESLint.LintResult[]>existingBatches,
 };
 
 function deepCopy<T>(data: T): T {
@@ -75,5 +79,13 @@ export default {
 
   singleFileTodoUpdated(tmp: string): ESLint.LintResult[] {
     return updatePaths(tmp, deepCopy(fixtures.singleFileTodoUpdated));
+  },
+
+  newBatches(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.newBatches));
+  },
+
+  existingBatches(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.existingBatches));
   },
 };

--- a/__tests__/__fixtures__/fixtures.ts
+++ b/__tests__/__fixtures__/fixtures.ts
@@ -10,8 +10,9 @@ import * as emberTemplateLintNoResults from './ember-template-lint-no-results.js
 import * as singleFileTodo from './single-file-todo.json';
 import * as singleFileNoErrors from './single-file-no-errors.json';
 import * as singleFileTodoUpdated from './single-file-todo-updated.json';
+import { updatePaths } from '../__utils__';
 
-export default {
+const fixtures = {
   eslintWithErrors: <ESLint.LintResult[]>(
     (<CLIEngine.LintReport>(eslintWithErrors as unknown)).results
   ),
@@ -33,4 +34,46 @@ export default {
   singleFileTodo: <ESLint.LintResult[]>singleFileTodo,
   singleFileNoErrors: <ESLint.LintResult[]>singleFileNoErrors,
   singleFileTodoUpdated: <ESLint.LintResult[]>singleFileTodoUpdated,
+};
+
+function deepCopy<T>(data: T): T {
+  return JSON.parse(JSON.stringify(data));
+}
+
+export default {
+  eslintWithErrors(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.eslintWithErrors));
+  },
+
+  eslintWithWarnings(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.eslintWithWarnings));
+  },
+
+  eslintNoResults(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.eslintNoResults));
+  },
+
+  emberTemplateLintWithErrors(tmp: string): TemplateLintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.emberTemplateLintWithErrors));
+  },
+
+  emberTemplateLintWithWarnings(tmp: string): TemplateLintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.emberTemplateLintWithWarnings));
+  },
+
+  emberTemplateLintNoResults(tmp: string): TemplateLintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.emberTemplateLintNoResults));
+  },
+
+  singleFileTodo(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.singleFileTodo));
+  },
+
+  singleFileNoErrors(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.singleFileNoErrors));
+  },
+
+  singleFileTodoUpdated(tmp: string): ESLint.LintResult[] {
+    return updatePaths(tmp, deepCopy(fixtures.singleFileTodoUpdated));
+  },
 };

--- a/__tests__/__fixtures__/new-batches.json
+++ b/__tests__/__fixtures__/new-batches.json
@@ -1,0 +1,79 @@
+[
+  {
+    "filePath": "{{path}}/app/controllers/settings.js",
+    "messages": [
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 25,
+        "column": 21,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 25,
+        "endColumn": 35
+      },
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 26,
+        "column": 19,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 26,
+        "endColumn": 33
+      },
+      {
+        "ruleId": "no-prototype-builtins",
+        "severity": 2,
+        "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+        "line": 32,
+        "column": 34,
+        "nodeType": "CallExpression",
+        "messageId": "prototypeBuildIn",
+        "endLine": 32,
+        "endColumn": 48
+      }
+    ],
+    "errorCount": 3,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "",
+    "usedDeprecatedRules": []
+  },
+  {
+    "filePath": "{{path}}/app/initializers/tracer.js",
+    "messages": [
+      {
+        "ruleId": "no-redeclare",
+        "severity": 2,
+        "message": "'window' is already defined as a built-in global variable.",
+        "line": 1,
+        "column": 11,
+        "nodeType": "Block",
+        "messageId": "redeclaredAsBuiltin",
+        "endLine": 1,
+        "endColumn": 17
+      },
+      {
+        "ruleId": "no-redeclare",
+        "severity": 2,
+        "message": "'XMLHttpRequest' is already defined as a built-in global variable.",
+        "line": 1,
+        "column": 19,
+        "nodeType": "Block",
+        "messageId": "redeclaredAsBuiltin",
+        "endLine": 1,
+        "endColumn": 33
+      }
+    ],
+    "errorCount": 2,
+    "warningCount": 0,
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "source": "",
+    "usedDeprecatedRules": []
+  }
+]

--- a/__tests__/__fixtures__/single-file-no-errors.json
+++ b/__tests__/__fixtures__/single-file-no-errors.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": "/Users/fake/app/controllers/settings.js",
+    "filePath": "{{path}}/app/controllers/settings.js",
     "messages": [],
     "errorCount": 0,
     "warningCount": 0,

--- a/__tests__/__fixtures__/single-file-todo-updated.json
+++ b/__tests__/__fixtures__/single-file-todo-updated.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": "/Users/fake/app/controllers/settings.js",
+    "filePath": "{{path}}/app/controllers/settings.js",
     "messages": [
       {
         "ruleId": "no-prototype-builtins",

--- a/__tests__/__fixtures__/single-file-todo.json
+++ b/__tests__/__fixtures__/single-file-todo.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": "/Users/fake/app/controllers/settings.js",
+    "filePath": "{{path}}/app/controllers/settings.js",
     "messages": [
       {
         "ruleId": "no-prototype-builtins",

--- a/__tests__/__utils__/index.ts
+++ b/__tests__/__utils__/index.ts
@@ -1,0 +1,2 @@
+export { createTmpDir } from './tmp-dir';
+export { updatePath, updatePaths } from './update-path';

--- a/__tests__/__utils__/update-path.ts
+++ b/__tests__/__utils__/update-path.ts
@@ -1,0 +1,13 @@
+export function updatePaths<T extends { filePath: string }>(path: string, data: T[]): T[] {
+  data.forEach((d) => (d.filePath = d.filePath.replace('{{path}}', path)));
+
+  return data;
+}
+
+export function updatePath<T extends { filePath: string }>(path: string, data: T): T {
+  const newData = { ...data };
+
+  newData.filePath = newData.filePath.replace('{{path}}', path);
+
+  return newData;
+}

--- a/__tests__/builders-test.ts
+++ b/__tests__/builders-test.ts
@@ -2,12 +2,20 @@ import { ESLint, Linter } from 'eslint';
 import { _buildTodoDatum, buildTodoData } from '../src';
 import { TemplateLintMessage, TemplateLintResult } from '../src/types';
 import fixtures from './__fixtures__/fixtures';
+import { createTmpDir } from './__utils__/tmp-dir';
+import { updatePath } from './__utils__/update-path';
 
 describe('builders', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = createTmpDir();
+  });
+
   describe('eslint', () => {
     it('builds a todo from eslint result', () => {
-      const eslintResult: ESLint.LintResult = {
-        filePath: '/Users/fake/app/controllers/settings.js',
+      const eslintResult: ESLint.LintResult = updatePath(tmp, {
+        filePath: '{{path}}/app/controllers/settings.js',
         messages: [
           {
             ruleId: 'no-prototype-builtins',
@@ -27,7 +35,7 @@ describe('builders', () => {
         fixableWarningCount: 0,
         source: '',
         usedDeprecatedRules: [],
-      };
+      });
 
       const eslintMessage: Linter.LintMessage = {
         ruleId: 'no-prototype-builtins',
@@ -41,12 +49,12 @@ describe('builders', () => {
         endColumn: 35,
       };
 
-      const todoDatum = _buildTodoDatum(eslintResult, eslintMessage);
+      const todoDatum = _buildTodoDatum(tmp, eslintResult, eslintMessage);
 
       expect(todoDatum).toEqual(
         expect.objectContaining({
           engine: 'eslint',
-          filePath: '/Users/fake/app/controllers/settings.js',
+          filePath: 'app/controllers/settings.js',
           ruleId: 'no-prototype-builtins',
           line: 25,
           column: 21,
@@ -55,19 +63,19 @@ describe('builders', () => {
     });
 
     it('can build todo data from results', () => {
-      const todoData = buildTodoData(fixtures.eslintWithErrors);
+      const todoData = buildTodoData(tmp, fixtures.eslintWithErrors(tmp));
 
       expect(todoData.size).toEqual(18);
     });
 
     it('can returns empty array with only warnings', () => {
-      const todoData = buildTodoData(fixtures.eslintWithWarnings);
+      const todoData = buildTodoData(tmp, fixtures.eslintWithWarnings(tmp));
 
       expect(todoData.size).toEqual(0);
     });
 
     it('can returns empty array with no results', () => {
-      const todoData = buildTodoData(fixtures.eslintNoResults);
+      const todoData = buildTodoData(tmp, fixtures.eslintNoResults(tmp));
 
       expect(todoData.size).toEqual(0);
     });
@@ -75,7 +83,7 @@ describe('builders', () => {
 
   describe('ember-template-lint', () => {
     it('builds a todo from eslint result', () => {
-      const emberTemplateLintResult: TemplateLintResult = {
+      const emberTemplateLintResult: TemplateLintResult = updatePath(tmp, {
         messages: [
           {
             rule: 'require-input-label',
@@ -88,9 +96,9 @@ describe('builders', () => {
           },
         ],
         errorCount: 2,
-        filePath: '/Users/fake/app/templates/components/add-ssh-key.hbs',
+        filePath: '{{path}}/app/templates/components/add-ssh-key.hbs',
         source: '',
-      };
+      });
 
       const emberTemplateLintMessage: TemplateLintMessage = {
         rule: 'require-input-label',
@@ -102,12 +110,12 @@ describe('builders', () => {
         source: '',
       };
 
-      const todoDatum = _buildTodoDatum(emberTemplateLintResult, emberTemplateLintMessage);
+      const todoDatum = _buildTodoDatum(tmp, emberTemplateLintResult, emberTemplateLintMessage);
 
       expect(todoDatum).toEqual(
         expect.objectContaining({
           engine: 'ember-template-lint',
-          filePath: '/Users/fake/app/templates/components/add-ssh-key.hbs',
+          filePath: 'app/templates/components/add-ssh-key.hbs',
           ruleId: 'require-input-label',
           line: 3,
           column: 4,
@@ -116,19 +124,19 @@ describe('builders', () => {
     });
 
     it('can build todo data from results', () => {
-      const todoData = buildTodoData(fixtures.emberTemplateLintWithErrors);
+      const todoData = buildTodoData(tmp, fixtures.emberTemplateLintWithErrors(tmp));
 
       expect(todoData.size).toEqual(39);
     });
 
     it('can returns empty array with only warnings', () => {
-      const todoData = buildTodoData(fixtures.emberTemplateLintWithWarnings);
+      const todoData = buildTodoData(tmp, fixtures.emberTemplateLintWithWarnings(tmp));
 
       expect(todoData.size).toEqual(0);
     });
 
     it('can returns empty array with no results', () => {
-      const todoData = buildTodoData(fixtures.emberTemplateLintNoResults);
+      const todoData = buildTodoData(tmp, fixtures.emberTemplateLintNoResults(tmp));
 
       expect(todoData.size).toEqual(0);
     });

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -259,162 +259,8 @@ describe('io', () => {
   });
 
   describe('getTodoBatches', () => {
-    let fromLintResults: LintResult[] = [
-      {
-        filePath: '{{path}}/app/controllers/settings.js',
-        messages: [
-          {
-            ruleId: 'no-prototype-builtins',
-            severity: 2,
-            message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-            line: 25,
-            column: 21,
-            nodeType: 'CallExpression',
-            messageId: 'prototypeBuildIn',
-            endLine: 25,
-            endColumn: 35,
-          },
-          {
-            ruleId: 'no-prototype-builtins',
-            severity: 2,
-            message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-            line: 26,
-            column: 19,
-            nodeType: 'CallExpression',
-            messageId: 'prototypeBuildIn',
-            endLine: 26,
-            endColumn: 33,
-          },
-          {
-            ruleId: 'no-prototype-builtins',
-            severity: 2,
-            message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-            line: 32,
-            column: 34,
-            nodeType: 'CallExpression',
-            messageId: 'prototypeBuildIn',
-            endLine: 32,
-            endColumn: 48,
-          },
-        ],
-        errorCount: 3,
-        warningCount: 0,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        source: '',
-        usedDeprecatedRules: [],
-      },
-      {
-        filePath: '{{path}}/app/initializers/tracer.js',
-        messages: [
-          {
-            ruleId: 'no-redeclare',
-            severity: 2,
-            message: "'window' is already defined as a built-in global variable.",
-            line: 1,
-            column: 11,
-            nodeType: 'Block',
-            messageId: 'redeclaredAsBuiltin',
-            endLine: 1,
-            endColumn: 17,
-          },
-          {
-            ruleId: 'no-redeclare',
-            severity: 2,
-            message: "'XMLHttpRequest' is already defined as a built-in global variable.",
-            line: 1,
-            column: 19,
-            nodeType: 'Block',
-            messageId: 'redeclaredAsBuiltin',
-            endLine: 1,
-            endColumn: 33,
-          },
-        ],
-        errorCount: 2,
-        warningCount: 0,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        source: '',
-        usedDeprecatedRules: [],
-      },
-    ];
-
-    let existing: LintResult[] = [
-      {
-        filePath: '{{path}}/app/initializers/tracer.js',
-        messages: [
-          {
-            ruleId: 'no-redeclare',
-            severity: 2,
-            message: "'window' is already defined as a built-in global variable.",
-            line: 1,
-            column: 11,
-            nodeType: 'Block',
-            messageId: 'redeclaredAsBuiltin',
-            endLine: 1,
-            endColumn: 17,
-          },
-          {
-            ruleId: 'no-redeclare',
-            severity: 2,
-            message: "'XMLHttpRequest' is already defined as a built-in global variable.",
-            line: 1,
-            column: 19,
-            nodeType: 'Block',
-            messageId: 'redeclaredAsBuiltin',
-            endLine: 1,
-            endColumn: 33,
-          },
-        ],
-        errorCount: 2,
-        warningCount: 0,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        source: '',
-        usedDeprecatedRules: [],
-      },
-      {
-        filePath: '{{path}}/app/models/build.js',
-        messages: [
-          {
-            ruleId: 'no-prototype-builtins',
-            severity: 2,
-            message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-            line: 108,
-            column: 50,
-            nodeType: 'CallExpression',
-            messageId: 'prototypeBuildIn',
-            endLine: 108,
-            endColumn: 64,
-          },
-          {
-            ruleId: 'no-prototype-builtins',
-            severity: 2,
-            message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-            line: 120,
-            column: 25,
-            nodeType: 'CallExpression',
-            messageId: 'prototypeBuildIn',
-            endLine: 120,
-            endColumn: 39,
-          },
-        ],
-        errorCount: 2,
-        warningCount: 0,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
-        source: '',
-        usedDeprecatedRules: [],
-      },
-    ];
-
-    beforeEach(() => {
-      fromLintResults = updatePaths(tmp, fromLintResults);
-      existing = updatePaths(tmp, existing);
-    });
-
     it('creates items to add', async () => {
-      const [add] = await getTodoBatches(buildTodoData(tmp, fromLintResults), new Map());
+      const [add] = await getTodoBatches(buildTodoData(tmp, fixtures.newBatches(tmp)), new Map());
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
@@ -428,42 +274,45 @@ describe('io', () => {
     });
 
     it('creates items to delete', async () => {
-      const [, remove] = await getTodoBatches(new Map(), buildTodoData(tmp, fromLintResults));
+      const [, remove] = await getTodoBatches(
+        new Map(),
+        buildTodoData(tmp, fixtures.newBatches(tmp))
+      );
 
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
-          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/6e3be839",
-          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/aad8bc25",
-          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/53e7a9a0",
-          "6b12ece7df9d1ae1be51f826307bd2a184841363/b9046d34",
-          "6b12ece7df9d1ae1be51f826307bd2a184841363/092271fa",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
         ]
       `);
     });
 
     it('creates all batches', async () => {
       const [add, remove, stable] = await getTodoBatches(
-        buildTodoData(tmp, fromLintResults),
-        buildTodoData(tmp, existing)
+        buildTodoData(tmp, fixtures.newBatches(tmp)),
+        buildTodoData(tmp, fixtures.existingBatches(tmp))
       );
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
-          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/6e3be839",
-          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/aad8bc25",
-          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/53e7a9a0",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
         ]
       `);
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
-          "cb6b583ddb4037f45158ae37df377b38a98a241e/66256fb7",
-          "cb6b583ddb4037f45158ae37df377b38a98a241e/8fd35486",
+          "07d3818b8afefcdd7db6d52743309fdbb85313f0/66256fb7",
+          "07d3818b8afefcdd7db6d52743309fdbb85313f0/8fd35486",
         ]
       `);
       expect([...stable.keys()]).toMatchInlineSnapshot(`
         Array [
-          "6b12ece7df9d1ae1be51f826307bd2a184841363/b9046d34",
-          "6b12ece7df9d1ae1be51f826307bd2a184841363/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
         ]
       `);
     });

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -11,10 +11,11 @@ import {
 import { LintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
 import fixtures from './__fixtures__/fixtures';
+import { updatePaths } from './__utils__';
 
 const TODO_DATA: TodoData = {
   engine: 'eslint',
-  filePath: '/Users/fake/app/controllers/settings.js',
+  filePath: 'app/controllers/settings.js',
   ruleId: 'no-prototype-builtins',
   line: 25,
   column: 21,
@@ -22,9 +23,9 @@ const TODO_DATA: TodoData = {
 };
 
 async function readFiles(todoStorageDir: string) {
-  const fileNames = [];
+  const fileNames: string[] = [];
   const todoFileDirs = await readdir(todoStorageDir);
-  debugger;
+
   for (const todoFileDir of todoFileDirs) {
     const files = (await readdir(join(todoStorageDir, todoFileDir))).map((file) =>
       join(todoFileDir, file)
@@ -37,6 +38,12 @@ async function readFiles(todoStorageDir: string) {
 }
 
 describe('io', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = createTmpDir();
+  });
+
   describe('todoFileNameFor', () => {
     it('can generate a unique hash for todo', () => {
       const fileName = todoFileNameFor(TODO_DATA);
@@ -57,7 +64,7 @@ describe('io', () => {
     it('can generate a unique dir hash for todo', () => {
       const dir = todoDirFor(TODO_DATA.filePath);
 
-      expect(dir).toEqual('42b8532cff6da75c5e5895a6f33522bf37418d0c');
+      expect(dir).toEqual('0a1e71cf4d0931e81f494d5a73a550016814e15a');
     });
 
     it('generates idempotent dir names', () => {
@@ -72,7 +79,7 @@ describe('io', () => {
     it('can generate a unique file path for todo', () => {
       const dir = todoFilePathFor(TODO_DATA);
 
-      expect(dir).toEqual('42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839');
+      expect(dir).toEqual('0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839');
     });
 
     it('generates idempotent file paths', () => {
@@ -84,12 +91,6 @@ describe('io', () => {
   });
 
   describe('writeTodos', () => {
-    let tmp: string;
-
-    beforeEach(() => {
-      tmp = createTmpDir();
-    });
-
     it("creates .lint-todo directory if one doesn't exist", async () => {
       const todoDir = await writeTodos(tmp, []);
 
@@ -103,7 +104,7 @@ describe('io', () => {
     });
 
     it('generates todos when todos provided', async () => {
-      const todoDir = await writeTodos(tmp, fixtures.eslintWithErrors);
+      const todoDir = await writeTodos(tmp, fixtures.eslintWithErrors(tmp));
 
       expect(await readFiles(todoDir)).toHaveLength(18);
     });
@@ -111,7 +112,7 @@ describe('io', () => {
     it("generates todos only if previous todo doesn't exist", async () => {
       const initialTodos: LintResult[] = [
         {
-          filePath: '/Users/fake/app/controllers/settings.js',
+          filePath: '{{path}}/app/controllers/settings.js',
           messages: [
             {
               ruleId: 'no-prototype-builtins',
@@ -145,7 +146,7 @@ describe('io', () => {
         },
       ];
 
-      const todoDir = await writeTodos(tmp, initialTodos);
+      const todoDir = await writeTodos(tmp, updatePaths<LintResult>(tmp, initialTodos));
 
       const initialFiles = await readFiles(todoDir);
 
@@ -158,7 +159,7 @@ describe('io', () => {
         };
       });
 
-      await writeTodos(tmp, fixtures.eslintWithErrors);
+      await writeTodos(tmp, fixtures.eslintWithErrors(tmp));
 
       const subsequentFiles = await readFiles(todoDir);
 
@@ -172,13 +173,14 @@ describe('io', () => {
     });
 
     it('removes old todos if todos no longer contains violations', async () => {
-      const todoDir = await writeTodos(tmp, fixtures.eslintWithErrors);
+      const fixture = fixtures.eslintWithErrors(tmp);
+      const todoDir = await writeTodos(tmp, fixture);
       const initialFiles = await readFiles(todoDir);
 
       expect(initialFiles).toHaveLength(18);
 
-      const firstHalf = fixtures.eslintWithErrors.slice(0, 3);
-      const secondHalf = fixtures.eslintWithErrors.slice(3, fixtures.eslintWithErrors.length);
+      const firstHalf = fixture.slice(0, 3);
+      const secondHalf = fixture.slice(3, fixture.length);
 
       await writeTodos(tmp, firstHalf);
 
@@ -186,31 +188,25 @@ describe('io', () => {
 
       expect(subsequentFiles).toHaveLength(7);
 
-      buildTodoData(secondHalf).forEach((todoDatum) => {
+      buildTodoData(tmp, secondHalf).forEach((todoDatum) => {
         expect(!existsSync(join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(true);
       });
     });
   });
 
   describe('writeTodos for single file', () => {
-    let tmp: string;
-
-    beforeEach(() => {
-      tmp = createTmpDir();
-    });
-
     it('generates todos for a specific filePath', async () => {
       const todoDir = await writeTodos(
         tmp,
-        fixtures.singleFileTodo,
-        '/Users/fake/app/controllers/settings.js'
+        fixtures.singleFileTodo(tmp),
+        'app/controllers/settings.js'
       );
 
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/53e7a9a0.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
         ]
       `);
     });
@@ -218,29 +214,25 @@ describe('io', () => {
     it('updates todos for a specific filePath', async () => {
       const todoDir = await writeTodos(
         tmp,
-        fixtures.singleFileTodo,
-        '/Users/fake/app/controllers/settings.js'
+        fixtures.singleFileTodo(tmp),
+        'app/controllers/settings.js'
       );
 
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/53e7a9a0.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
         ]
       `);
 
-      await writeTodos(
-        tmp,
-        fixtures.singleFileTodoUpdated,
-        '/Users/fake/app/controllers/settings.js'
-      );
+      await writeTodos(tmp, fixtures.singleFileTodoUpdated(tmp), 'app/controllers/settings.js');
 
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/ee492fc4.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/ee492fc4.json",
         ]
       `);
     });
@@ -248,28 +240,28 @@ describe('io', () => {
     it('deletes todos for a specific filePath', async () => {
       const todoDir = await writeTodos(
         tmp,
-        fixtures.singleFileTodo,
-        '/Users/fake/app/controllers/settings.js'
+        fixtures.singleFileTodo(tmp),
+        'app/controllers/settings.js'
       );
 
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/53e7a9a0.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839.json",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
         ]
       `);
 
-      await writeTodos(tmp, fixtures.singleFileNoErrors, '/Users/fake/app/controllers/settings.js');
+      await writeTodos(tmp, fixtures.singleFileNoErrors(tmp), 'app/controllers/settings.js');
 
       expect(await readFiles(todoDir)).toHaveLength(0);
     });
   });
 
   describe('getTodoBatches', () => {
-    const fromLintResults: LintResult[] = [
+    const fromLintResults: LintResult[] = updatePaths(tmp, [
       {
-        filePath: '/Users/fake/app/controllers/settings.js',
+        filePath: '{{path}}/app/controllers/settings.js',
         messages: [
           {
             ruleId: 'no-prototype-builtins',
@@ -313,7 +305,7 @@ describe('io', () => {
         usedDeprecatedRules: [],
       },
       {
-        filePath: '/Users/fake/app/initializers/tracer.js',
+        filePath: '{{path}}/app/initializers/tracer.js',
         messages: [
           {
             ruleId: 'no-redeclare',
@@ -345,11 +337,11 @@ describe('io', () => {
         source: '',
         usedDeprecatedRules: [],
       },
-    ];
+    ]);
 
-    const existing: LintResult[] = [
+    const existing: LintResult[] = updatePaths(tmp, [
       {
-        filePath: '/Users/fake/app/initializers/tracer.js',
+        filePath: '{{path}}/app/initializers/tracer.js',
         messages: [
           {
             ruleId: 'no-redeclare',
@@ -382,7 +374,7 @@ describe('io', () => {
         usedDeprecatedRules: [],
       },
       {
-        filePath: '/Users/fake/app/models/build.js',
+        filePath: '{{path}}/app/models/build.js',
         messages: [
           {
             ruleId: 'no-prototype-builtins',
@@ -414,59 +406,59 @@ describe('io', () => {
         source: '',
         usedDeprecatedRules: [],
       },
-    ];
+    ]);
 
     it('creates items to add', async () => {
-      const [add] = await getTodoBatches(buildTodoData(fromLintResults), new Map());
+      const [add] = await getTodoBatches(buildTodoData(tmp, fromLintResults), new Map());
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/53e7a9a0",
-          "1ca7789ad58b87fa44470777e587667b2d4c191c/b9046d34",
-          "1ca7789ad58b87fa44470777e587667b2d4c191c/092271fa",
+          "81309a57ca1cdac030492a81c1cece31113117e1/6e3be839",
+          "81309a57ca1cdac030492a81c1cece31113117e1/aad8bc25",
+          "81309a57ca1cdac030492a81c1cece31113117e1/53e7a9a0",
+          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/b9046d34",
+          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/092271fa",
         ]
       `);
     });
 
     it('creates items to delete', async () => {
-      const [, remove] = await getTodoBatches(new Map(), buildTodoData(fromLintResults));
+      const [, remove] = await getTodoBatches(new Map(), buildTodoData(tmp, fromLintResults));
 
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/53e7a9a0",
-          "1ca7789ad58b87fa44470777e587667b2d4c191c/b9046d34",
-          "1ca7789ad58b87fa44470777e587667b2d4c191c/092271fa",
+          "81309a57ca1cdac030492a81c1cece31113117e1/6e3be839",
+          "81309a57ca1cdac030492a81c1cece31113117e1/aad8bc25",
+          "81309a57ca1cdac030492a81c1cece31113117e1/53e7a9a0",
+          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/b9046d34",
+          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/092271fa",
         ]
       `);
     });
 
     it('creates all batches', async () => {
       const [add, remove, stable] = await getTodoBatches(
-        buildTodoData(fromLintResults),
-        buildTodoData(existing)
+        buildTodoData(tmp, fromLintResults),
+        buildTodoData(tmp, existing)
       );
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/aad8bc25",
-          "42b8532cff6da75c5e5895a6f33522bf37418d0c/53e7a9a0",
+          "81309a57ca1cdac030492a81c1cece31113117e1/6e3be839",
+          "81309a57ca1cdac030492a81c1cece31113117e1/aad8bc25",
+          "81309a57ca1cdac030492a81c1cece31113117e1/53e7a9a0",
         ]
       `);
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
-          "e0ab64604b96684307a69bb57e5f76ab613f868d/66256fb7",
-          "e0ab64604b96684307a69bb57e5f76ab613f868d/8fd35486",
+          "854da59dc2788ca1f8754f5e00528102427a155f/66256fb7",
+          "854da59dc2788ca1f8754f5e00528102427a155f/8fd35486",
         ]
       `);
       expect([...stable.keys()]).toMatchInlineSnapshot(`
         Array [
-          "1ca7789ad58b87fa44470777e587667b2d4c191c/b9046d34",
-          "1ca7789ad58b87fa44470777e587667b2d4c191c/092271fa",
+          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/b9046d34",
+          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/092271fa",
         ]
       `);
     });

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -259,7 +259,7 @@ describe('io', () => {
   });
 
   describe('getTodoBatches', () => {
-    const fromLintResults: LintResult[] = updatePaths(tmp, [
+    let fromLintResults: LintResult[] = [
       {
         filePath: '{{path}}/app/controllers/settings.js',
         messages: [
@@ -337,9 +337,9 @@ describe('io', () => {
         source: '',
         usedDeprecatedRules: [],
       },
-    ]);
+    ];
 
-    const existing: LintResult[] = updatePaths(tmp, [
+    let existing: LintResult[] = [
       {
         filePath: '{{path}}/app/initializers/tracer.js',
         messages: [
@@ -406,18 +406,23 @@ describe('io', () => {
         source: '',
         usedDeprecatedRules: [],
       },
-    ]);
+    ];
+
+    beforeEach(() => {
+      fromLintResults = updatePaths(tmp, fromLintResults);
+      existing = updatePaths(tmp, existing);
+    });
 
     it('creates items to add', async () => {
       const [add] = await getTodoBatches(buildTodoData(tmp, fromLintResults), new Map());
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
-          "81309a57ca1cdac030492a81c1cece31113117e1/6e3be839",
-          "81309a57ca1cdac030492a81c1cece31113117e1/aad8bc25",
-          "81309a57ca1cdac030492a81c1cece31113117e1/53e7a9a0",
-          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/b9046d34",
-          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/092271fa",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
         ]
       `);
     });
@@ -427,11 +432,11 @@ describe('io', () => {
 
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
-          "81309a57ca1cdac030492a81c1cece31113117e1/6e3be839",
-          "81309a57ca1cdac030492a81c1cece31113117e1/aad8bc25",
-          "81309a57ca1cdac030492a81c1cece31113117e1/53e7a9a0",
-          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/b9046d34",
-          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/092271fa",
+          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/6e3be839",
+          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/aad8bc25",
+          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/53e7a9a0",
+          "6b12ece7df9d1ae1be51f826307bd2a184841363/b9046d34",
+          "6b12ece7df9d1ae1be51f826307bd2a184841363/092271fa",
         ]
       `);
     });
@@ -444,21 +449,21 @@ describe('io', () => {
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
-          "81309a57ca1cdac030492a81c1cece31113117e1/6e3be839",
-          "81309a57ca1cdac030492a81c1cece31113117e1/aad8bc25",
-          "81309a57ca1cdac030492a81c1cece31113117e1/53e7a9a0",
+          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/6e3be839",
+          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/aad8bc25",
+          "dd0e5ad04d85be2e4cb19b2a934bd41a122db843/53e7a9a0",
         ]
       `);
       expect([...remove.keys()]).toMatchInlineSnapshot(`
         Array [
-          "854da59dc2788ca1f8754f5e00528102427a155f/66256fb7",
-          "854da59dc2788ca1f8754f5e00528102427a155f/8fd35486",
+          "cb6b583ddb4037f45158ae37df377b38a98a241e/66256fb7",
+          "cb6b583ddb4037f45158ae37df377b38a98a241e/8fd35486",
         ]
       `);
       expect([...stable.keys()]).toMatchInlineSnapshot(`
         Array [
-          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/b9046d34",
-          "faf339f75c23ae67324db8bf2e4ce5bbaa8128f0/092271fa",
+          "6b12ece7df9d1ae1be51f826307bd2a184841363/b9046d34",
+          "6b12ece7df9d1ae1be51f826307bd2a184841363/092271fa",
         ]
       `);
     });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^3.9.3"
   },
   "engines": {
-    "node": ">= 12"
+    "node": "10.* || 12.* || >= 14"
   },
   "files": [
     "lib/"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "ts-jest": "^26.4.0",
     "typescript": "^3.9.3"
   },
+  "engines": {
+    "node": ">= 12"
+  },
   "files": [
     "lib/"
   ],

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,3 +1,4 @@
+import { relative } from 'path';
 import { todoFilePathFor } from './io';
 import { FilePath, LintMessage, LintResult, TodoData } from './types';
 
@@ -5,15 +6,16 @@ import { FilePath, LintMessage, LintResult, TodoData } from './types';
  * Adapts a list of {@link https://github.com/DefinitelyTyped/DefinitelyTyped/blob/160f43ae6852c4eefec2641e54cff96dd7b63488/types/eslint/index.d.ts#L640 ESLint.LintResult}
  * or {@link TemplateLintResult} to a map of {@link FilePath}, {@link TodoData}.
  *
+ * @param baseDir The base directory that contains the .lint-todo storage directory.
  * @param lintResults A list of {LintResult} objects to convert to {TodoData} objects.
  */
-export function buildTodoData(lintResults: LintResult[]): Map<FilePath, TodoData> {
+export function buildTodoData(baseDir: string, lintResults: LintResult[]): Map<FilePath, TodoData> {
   const results = lintResults.filter((result) => result.messages.length > 0);
 
   const todoData = results.reduce((converted, lintResult) => {
     lintResult.messages.forEach((message: LintMessage) => {
       if (message.severity === 2) {
-        const todoDatum = _buildTodoDatum(lintResult, message);
+        const todoDatum = _buildTodoDatum(baseDir, lintResult, message);
 
         converted.set(todoFilePathFor(todoDatum), todoDatum);
       }
@@ -26,15 +28,21 @@ export function buildTodoData(lintResults: LintResult[]): Map<FilePath, TodoData
 }
 
 /**
- * Adapts an {ESLint.LintResult} or {TemplateLintResult} to a {TodoData}
+ * Adapts an {ESLint.LintResult} or {TemplateLintResult} to a {TodoData}. FilePaths are absolute
+ * when received from a lint result, so they're converted to relative paths for stability in
+ * serializing the contents to disc.
  *
  * @param lintResult The lint result object, either an {ESLint.LintResult} or a {TemplateLintResult}.
  * @param lintMessage A lint message object representing a specific violation for a file.
  */
-export function _buildTodoDatum(lintResult: LintResult, lintMessage: LintMessage): TodoData {
+export function _buildTodoDatum(
+  baseDir: string,
+  lintResult: LintResult,
+  lintMessage: LintMessage
+): TodoData {
   return {
     engine: getEngine(lintResult),
-    filePath: lintResult.filePath,
+    filePath: relative(baseDir, lintResult.filePath),
     ruleId: getRuleId(lintMessage),
     line: lintMessage.line,
     column: lintMessage.column,

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { join, parse, relative } from 'path';
+import { join, parse } from 'path';
 import { ensureDir, readdir, readJSON, unlink, writeJson } from 'fs-extra';
 import { buildTodoData } from './builders';
 import { FilePath, LintResult, TodoData } from './types';

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { join, parse } from 'path';
+import { join, parse, relative } from 'path';
 import { ensureDir, readdir, readJSON, unlink, writeJson } from 'fs-extra';
 import { buildTodoData } from './builders';
 import { FilePath, LintResult, TodoData } from './types';
@@ -30,6 +30,7 @@ export function getTodoStorageDirPath(baseDir: string): string {
  * @example
  * 42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839
  *
+ * @param baseDir The base directory that contains the .lint-todo storage directory.
  * @param todoData The linting data for an individual violation.
  */
 export function todoFilePathFor(todoData: TodoData): string {
@@ -76,7 +77,7 @@ export async function writeTodos(
   const existing: Map<FilePath, TodoData> = filePath
     ? await readTodosForFilePath(todoStorageDir, filePath)
     : await readTodos(todoStorageDir);
-  const [add, remove] = await getTodoBatches(buildTodoData(lintResults), existing);
+  const [add, remove] = await getTodoBatches(buildTodoData(baseDir, lintResults), existing);
 
   await _generateFiles(todoStorageDir, add, remove);
 
@@ -112,10 +113,10 @@ export async function readTodos(todoStorageDir: string): Promise<Map<FilePath, T
  */
 export async function readTodosForFilePath(
   todoStorageDir: string,
-  filesDirOrPath: string
+  filePath: string
 ): Promise<Map<FilePath, TodoData>> {
   const map = new Map();
-  const todoFileDir = todoDirFor(filesDirOrPath);
+  const todoFileDir = todoDirFor(filePath);
   const todoFilePathDir = join(todoStorageDir, todoFileDir);
 
   try {


### PR DESCRIPTION
Currently, lint results (both `eslint` and `ember-template-lint`) return results that include absolute paths for the `filePath` property. Persisting this data would result in the todos being non-deterministic from machine to machine.

This change converts absolute paths to relative paths, enabling us to have true deterministic todo storage.