### PR TITLE
Aligning APIs for consistency

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -7,8 +7,8 @@ import {
   todoDirFor,
   todoFileNameFor,
   todoFilePathFor,
-  todoDirExists,
-  ensureTodoDir,
+  todoStorageDirExists,
+  ensureTodoStorageDir,
 } from '../src';
 import { LintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
@@ -46,15 +46,15 @@ describe('io', () => {
     tmp = createTmpDir();
   });
 
-  describe('todoDirExists', () => {
+  describe('todoStorageDirExists', () => {
     it('returns false when directory does not exist', async () => {
-      expect(await todoDirExists(tmp)).toEqual(false);
+      expect(todoStorageDirExists(tmp)).toEqual(false);
     });
 
     it('returns true when directory exists', async () => {
-      await ensureTodoDir(tmp);
+      await ensureTodoStorageDir(tmp);
 
-      expect(await todoDirExists(tmp)).toEqual(true);
+      expect(todoStorageDirExists(tmp)).toEqual(true);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "tsc --build --clean",
     "lint": "eslint . --ext .ts",
     "prepare": "yarn build",
-    "test": "jest --passWithNoTests --no-cache"
+    "test": "jest --no-cache"
   },
   "dependencies": {
     "fs-extra": "^9.0.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export { _buildTodoDatum, buildTodoData } from './builders';
 export {
-  ensureTodoDir,
+  ensureTodoStorageDir,
   getTodoStorageDirPath,
   getTodoBatches,
-  todoDirExists,
+  todoStorageDirExists,
   todoDirFor,
   todoFileNameFor,
   todoFilePathFor,

--- a/src/io.ts
+++ b/src/io.ts
@@ -4,6 +4,11 @@ import { ensureDir, existsSync, readdir, readJSON, unlink, writeJson } from 'fs-
 import { buildTodoData } from './builders';
 import { FilePath, LintResult, TodoData } from './types';
 
+/**
+ * Determines if the .lint-todo storage directory exists.
+ *
+ * @param baseDir The base directory that contains the .lint-todo storage directory.
+ */
 export function todoStorageDirExists(baseDir: string): boolean {
   return existsSync(getTodoStorageDirPath(baseDir));
 }
@@ -91,7 +96,7 @@ export async function writeTodos(
 /**
  * Reads all todo files in the .lint-todo directory.
  *
- * @param todoStorageDir The .lint-todo storage directory.
+ * @param baseDir The base directory that contains the .lint-todo storage directory.
  */
 export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData>> {
   const map = new Map();

--- a/src/io.ts
+++ b/src/io.ts
@@ -79,8 +79,8 @@ export async function writeTodos(
 ): Promise<string> {
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const existing: Map<FilePath, TodoData> = filePath
-    ? await readTodosForFilePath(todoStorageDir, filePath)
-    : await readTodos(todoStorageDir);
+    ? await readTodosForFilePath(baseDir, filePath)
+    : await readTodos(baseDir);
   const [add, remove] = await getTodoBatches(buildTodoData(baseDir, lintResults), existing);
 
   await _generateFiles(todoStorageDir, add, remove);
@@ -93,8 +93,9 @@ export async function writeTodos(
  *
  * @param todoStorageDir The .lint-todo storage directory.
  */
-export async function readTodos(todoStorageDir: string): Promise<Map<FilePath, TodoData>> {
+export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData>> {
   const map = new Map();
+  const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const todoFileDirs = await readdir(todoStorageDir);
 
   for (const todoFileDir of todoFileDirs) {
@@ -116,10 +117,11 @@ export async function readTodos(todoStorageDir: string): Promise<Map<FilePath, T
  * @param filePath The relative file path of the file to return todo items for.
  */
 export async function readTodosForFilePath(
-  todoStorageDir: string,
+  baseDir: string,
   filePath: string
 ): Promise<Map<FilePath, TodoData>> {
   const map = new Map();
+  const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const todoFileDir = todoDirFor(filePath);
   const todoFilePathDir = join(todoStorageDir, todoFileDir);
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,24 +1,11 @@
 import { createHash } from 'crypto';
 import { join, parse } from 'path';
-import { promisify } from 'util';
-import { access } from 'fs';
-import { ensureDir, readdir, readJSON, unlink, writeJson } from 'fs-extra';
+import { ensureDir, existsSync, readdir, readJSON, unlink, writeJson } from 'fs-extra';
 import { buildTodoData } from './builders';
 import { FilePath, LintResult, TodoData } from './types';
 
-const exists = promisify(access);
-
-export async function todoDirExists(baseDir: string): Promise<boolean> {
-  try {
-    await exists(getTodoStorageDirPath(baseDir));
-    return true;
-  } catch (error) {
-    if (error.code === 'ENOENT') {
-      return false;
-    }
-
-    throw error;
-  }
+export function todoStorageDirExists(baseDir: string): boolean {
+  return existsSync(getTodoStorageDirPath(baseDir));
 }
 
 /**
@@ -26,7 +13,7 @@ export async function todoDirExists(baseDir: string): Promise<boolean> {
  *
  * @param baseDir The base directory that contains the .lint-todo storage directory.
  */
-export async function ensureTodoDir(baseDir: string): Promise<string> {
+export async function ensureTodoStorageDir(baseDir: string): Promise<string> {
   const path = getTodoStorageDirPath(baseDir);
 
   await ensureDir(path);
@@ -90,7 +77,7 @@ export async function writeTodos(
   lintResults: LintResult[],
   filePath?: string
 ): Promise<string> {
-  const todoStorageDir: string = await ensureTodoDir(baseDir);
+  const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const existing: Map<FilePath, TodoData> = filePath
     ? await readTodosForFilePath(todoStorageDir, filePath)
     : await readTodos(todoStorageDir);


### PR DESCRIPTION
The public APIs were using inconsistent parameters. Sometimes they'd use `baseDir`, and some would use `todoStorageDir`. This change realigns the public APIs to ensure they're consistent, which will help with usage.