### PR TITLE
Fixes #28: file path consistency

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node: ['12']
 
     steps:

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdir, statSync } from 'fs-extra';
-import { join } from 'path';
+import { posix } from 'path';
 import {
   buildTodoData,
   writeTodos,
@@ -29,8 +29,8 @@ async function readFiles(todoStorageDir: string) {
   const todoFileDirs = await readdir(todoStorageDir);
 
   for (const todoFileDir of todoFileDirs) {
-    const files = (await readdir(join(todoStorageDir, todoFileDir))).map((file) =>
-      join(todoFileDir, file)
+    const files = (await readdir(posix.join(todoStorageDir, todoFileDir))).map((file) =>
+      posix.join(todoFileDir, file)
     );
 
     fileNames.push(...files);
@@ -169,7 +169,7 @@ describe('io', () => {
       const initialFileStats = initialFiles.map((file) => {
         return {
           fileName: file,
-          ctime: statSync(join(todoDir, file)).ctime,
+          ctime: statSync(posix.join(todoDir, file)).ctime,
         };
       });
 
@@ -180,7 +180,7 @@ describe('io', () => {
       expect(subsequentFiles).toHaveLength(18);
 
       initialFileStats.forEach((initialFileStat) => {
-        const subsequentFile = statSync(join(todoDir, initialFileStat.fileName));
+        const subsequentFile = statSync(posix.join(todoDir, initialFileStat.fileName));
 
         expect(subsequentFile.ctime).toEqual(initialFileStat.ctime);
       });
@@ -203,7 +203,7 @@ describe('io', () => {
       expect(subsequentFiles).toHaveLength(7);
 
       buildTodoData(tmp, secondHalf).forEach((todoDatum) => {
-        expect(!existsSync(join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(true);
+        expect(!existsSync(posix.join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(true);
       });
     });
   });

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,4 +1,4 @@
-import { relative } from 'path';
+import { posix } from 'path';
 import { todoFilePathFor } from './io';
 import { FilePath, LintMessage, LintResult, TodoData } from './types';
 
@@ -42,7 +42,7 @@ export function _buildTodoDatum(
 ): TodoData {
   return {
     engine: getEngine(lintResult),
-    filePath: relative(baseDir, lintResult.filePath),
+    filePath: posix.relative(baseDir, lintResult.filePath),
     ruleId: getRuleId(lintMessage),
     line: lintMessage.line,
     column: lintMessage.column,

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { join, parse } from 'path';
+import { posix } from 'path';
 import { ensureDir, existsSync, readdir, readJSON, unlink, writeJson } from 'fs-extra';
 import { buildTodoData } from './builders';
 import { FilePath, LintResult, TodoData } from './types';
@@ -30,7 +30,7 @@ export async function ensureTodoStorageDir(baseDir: string): Promise<string> {
  * @param baseDir The base directory that contains the .lint-todo storage directory.
  */
 export function getTodoStorageDirPath(baseDir: string): string {
-  return join(baseDir, '.lint-todo');
+  return posix.join(baseDir, '.lint-todo');
 }
 
 /**
@@ -43,7 +43,7 @@ export function getTodoStorageDirPath(baseDir: string): string {
  * @param todoData The linting data for an individual violation.
  */
 export function todoFilePathFor(todoData: TodoData): string {
-  return join(todoDirFor(todoData.filePath), todoFileNameFor(todoData));
+  return posix.join(todoDirFor(todoData.filePath), todoFileNameFor(todoData));
 }
 
 /**
@@ -104,11 +104,11 @@ export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData
   const todoFileDirs = await readdir(todoStorageDir);
 
   for (const todoFileDir of todoFileDirs) {
-    const fileNames = await readdir(join(todoStorageDir, todoFileDir));
+    const fileNames = await readdir(posix.join(todoStorageDir, todoFileDir));
 
     for (const fileName of fileNames) {
-      const todo = await readJSON(join(todoStorageDir, todoFileDir, fileName));
-      map.set(join(todoFileDir, parse(fileName).name), todo);
+      const todo = await readJSON(posix.join(todoStorageDir, todoFileDir, fileName));
+      map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
     }
   }
 
@@ -128,14 +128,14 @@ export async function readTodosForFilePath(
   const map = new Map();
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const todoFileDir = todoDirFor(filePath);
-  const todoFilePathDir = join(todoStorageDir, todoFileDir);
+  const todoFilePathDir = posix.join(todoStorageDir, todoFileDir);
 
   try {
     const fileNames = await readdir(todoFilePathDir);
 
     for (const fileName of fileNames) {
-      const todo = await readJSON(join(todoFilePathDir, fileName));
-      map.set(join(todoFileDir, parse(fileName).name), todo);
+      const todo = await readJSON(posix.join(todoFilePathDir, fileName));
+      map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
     }
   } catch (error) {
     if (error.code === 'ENOENT') {
@@ -187,13 +187,13 @@ async function _generateFiles(
   remove: Map<FilePath, TodoData>
 ) {
   for (const [fileHash, todoDatum] of add) {
-    const { dir } = parse(fileHash);
+    const { dir } = posix.parse(fileHash);
 
-    await ensureDir(join(todoStorageDir, dir));
-    await writeJson(join(todoStorageDir, `${fileHash}.json`), todoDatum);
+    await ensureDir(posix.join(todoStorageDir, dir));
+    await writeJson(posix.join(todoStorageDir, `${fileHash}.json`), todoDatum);
   }
 
   for (const [fileHash] of remove) {
-    await unlink(join(todoStorageDir, `${fileHash}.json`));
+    await unlink(posix.join(todoStorageDir, `${fileHash}.json`));
   }
 }


### PR DESCRIPTION
Addresses issue #28: File paths are currently not consistent across different platforms (Posix vs Win32). Per [node's spec](https://nodejs.org/api/path.html#path_windows_vs_posix), to achieve consistent results across platforms we need to use `path.posix` or `path.win32`. Tests should also run on Windows to check for cross platform compatibility issues.