### PR TITLE
Fix path for todo data so it's consistent on posix and win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "slash": "^3.0.0"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.3",
     "@types/fs-extra": "^9.0.1",
+    "@types/slash": "^3.0.0",
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,4 +1,5 @@
-import { posix } from 'path';
+import { isAbsolute, relative } from 'path';
+import slash = require('slash');
 import { todoFilePathFor } from './io';
 import { FilePath, LintMessage, LintResult, TodoData } from './types';
 
@@ -40,9 +41,14 @@ export function _buildTodoDatum(
   lintResult: LintResult,
   lintMessage: LintMessage
 ): TodoData {
+  /**
+   * Note: If https://github.com/nodejs/node/issues/13683 is fixed, remove slash() and use posix.relative
+   * provided that the fix is landed on the supported node versions of this lib
+   */
+  const filePath = isAbsolute(lintResult.filePath) ? relative(baseDir, lintResult.filePath) : lintResult.filePath;
   return {
     engine: getEngine(lintResult),
-    filePath: posix.relative(baseDir, lintResult.filePath),
+    filePath: slash(filePath),
     ruleId: getRuleId(lintMessage),
     line: lintMessage.line,
     column: lintMessage.column,

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,6 +799,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/slash@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/slash/-/slash-3.0.0.tgz#87e9373e5ae6df7732f86a4548b8b2eb280a6c4f"
+  integrity sha512-bmUaw0IUPUVldtj4YwU7tbzxllQQgsWdnB45bwTI0f1Lq2Yg8lT2yxV4OGZrMTrP/G9v8eVIhX130xPe/RfPfw==
+  dependencies:
+    slash "*"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -5094,7 +5101,7 @@ sisteransi@^1.0.4:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
-slash@^3.0.0:
+slash@*, slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==


### PR DESCRIPTION
`posix.relative` was returning an incorrect path for Windows (`../app/app.js` vs `app/app.js`) which was not consistent with the behavior on posix.

It looks like this is an known issue based on the following issues:

- https://github.com/nodejs/node/issues/13887
- https://github.com/nodejs/node/issues/13683

Since `path.relative` works correctly, we just need to normalize the path using the `slash` lib. Also, if the file path is already relative (this happens for `ember-template-lint`) then we can ignore the relative call, preventing the issue cited above.