### PR TITLE
Adding sync APIs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ serializing the contents to disc.</p>
 <dt><a href="#todoStorageDirExists">todoStorageDirExists(baseDir)</a> ⇒</dt>
 <dd><p>Determines if the .lint-todo storage directory exists.</p>
 </dd>
+<dt><a href="#ensureTodoStorageDirSync">ensureTodoStorageDirSync(baseDir)</a> ⇒</dt>
+<dd><p>Creates, or ensures the creation of, the .lint-todo directory.</p>
+</dd>
 <dt><a href="#ensureTodoStorageDir">ensureTodoStorageDir(baseDir)</a> ⇒</dt>
 <dd><p>Creates, or ensures the creation of, the .lint-todo directory.</p>
 </dd>
@@ -41,20 +44,38 @@ serializing the contents to disc.</p>
 <dt><a href="#todoFileNameFor">todoFileNameFor(todoData)</a> ⇒</dt>
 <dd><p>Generates a unique filename for a todo lint data.</p>
 </dd>
+<dt><a href="#writeTodosSync">writeTodosSync(baseDir, lintResults, filePath, daysToDecay)</a> ⇒</dt>
+<dd><p>Writes files for todo lint violations. One file is generated for each violation, using a generated
+hash to identify each.</p>
+<p>Given a list of todo lint violations, this function will also delete existing files that no longer
+have a todo lint violation.</p>
+</dd>
 <dt><a href="#writeTodos">writeTodos(baseDir, lintResults, filePath, daysToDecay)</a> ⇒</dt>
 <dd><p>Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.</p>
 <p>Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.</p>
 </dd>
+<dt><a href="#readTodosSync">readTodosSync(baseDir)</a> ⇒</dt>
+<dd><p>Reads all todo files in the .lint-todo directory.</p>
+</dd>
 <dt><a href="#readTodos">readTodos(baseDir)</a> ⇒</dt>
 <dd><p>Reads all todo files in the .lint-todo directory.</p>
+</dd>
+<dt><a href="#readTodosForFilePathSync">readTodosForFilePathSync(todoStorageDir, filePath)</a> ⇒</dt>
+<dd><p>Reads todo files in the .lint-todo directory for a specific filePath.</p>
 </dd>
 <dt><a href="#readTodosForFilePath">readTodosForFilePath(todoStorageDir, filePath)</a> ⇒</dt>
 <dd><p>Reads todo files in the .lint-todo directory for a specific filePath.</p>
 </dd>
+<dt><a href="#getTodoBatchesSync">getTodoBatchesSync(lintResults, existing)</a> ⇒</dt>
+<dd><p>Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).</p>
+</dd>
 <dt><a href="#getTodoBatches">getTodoBatches(lintResults, existing)</a> ⇒</dt>
 <dd><p>Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).</p>
+</dd>
+<dt><a href="#applyTodoChangesSync">applyTodoChangesSync(todoStorageDir, add, remove)</a></dt>
+<dd><p>Applies todo changes, either adding or removing, based on batches from <code>getTodoBatches</code>.</p>
 </dd>
 <dt><a href="#applyTodoChanges">applyTodoChanges(todoStorageDir, add, remove)</a></dt>
 <dd><p>Applies todo changes, either adding or removing, based on batches from <code>getTodoBatches</code>.</p>
@@ -103,13 +124,25 @@ Determines if the .lint-todo storage directory exists.
 | --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
+<a name="ensureTodoStorageDirSync"></a>
+
+## ensureTodoStorageDirSync(baseDir) ⇒
+Creates, or ensures the creation of, the .lint-todo directory.
+
+**Kind**: global function  
+**Returns**: - The todo storage directory path.  
+
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage directory. |
+
 <a name="ensureTodoStorageDir"></a>
 
 ## ensureTodoStorageDir(baseDir) ⇒
 Creates, or ensures the creation of, the .lint-todo directory.
 
 **Kind**: global function  
-**Returns**: - The todo storage directory path.  
+**Returns**: - A promise that resolves to the todo storage directory path.  
 
 | Param | Description |
 | --- | --- |
@@ -166,9 +199,9 @@ Generates a unique filename for a todo lint data.
 | --- | --- |
 | todoData | The linting data for an individual violation. |
 
-<a name="writeTodos"></a>
+<a name="writeTodosSync"></a>
 
-## writeTodos(baseDir, lintResults, filePath, daysToDecay) ⇒
+## writeTodosSync(baseDir, lintResults, filePath, daysToDecay) ⇒
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
@@ -185,17 +218,61 @@ have a todo lint violation.
 | filePath | The relative file path of the file to update violations for. |
 | daysToDecay | An object containing the warn or error days, in integers. |
 
+<a name="writeTodos"></a>
+
+## writeTodos(baseDir, lintResults, filePath, daysToDecay) ⇒
+Writes files for todo lint violations. One file is generated for each violation, using a generated
+hash to identify each.
+
+Given a list of todo lint violations, this function will also delete existing files that no longer
+have a todo lint violation.
+
+**Kind**: global function  
+**Returns**: - A promise that resolves to the todo storage directory path.  
+
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage directory. |
+| lintResults | The raw linting data. |
+| filePath | The relative file path of the file to update violations for. |
+| daysToDecay | An object containing the warn or error days, in integers. |
+
+<a name="readTodosSync"></a>
+
+## readTodosSync(baseDir) ⇒
+Reads all todo files in the .lint-todo directory.
+
+**Kind**: global function  
+**Returns**: - A [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
+
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage directory. |
+
 <a name="readTodos"></a>
 
 ## readTodos(baseDir) ⇒
 Reads all todo files in the .lint-todo directory.
 
 **Kind**: global function  
-**Returns**: - A Promise resolving to a [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
+**Returns**: - A Promise that resolves to a [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
 
 | Param | Description |
 | --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
+
+<a name="readTodosForFilePathSync"></a>
+
+## readTodosForFilePathSync(todoStorageDir, filePath) ⇒
+Reads todo files in the .lint-todo directory for a specific filePath.
+
+**Kind**: global function  
+**Returns**: - A [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
+
+| Param | Description |
+| --- | --- |
+| todoStorageDir | The .lint-todo storage directory. |
+| filePath | The relative file path of the file to return todo items for. |
 
 <a name="readTodosForFilePath"></a>
 
@@ -203,12 +280,25 @@ Reads all todo files in the .lint-todo directory.
 Reads todo files in the .lint-todo directory for a specific filePath.
 
 **Kind**: global function  
-**Returns**: - A Promise resolving to a [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
+**Returns**: - A Promise that resolves to a [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
 
 | Param | Description |
 | --- | --- |
 | todoStorageDir | The .lint-todo storage directory. |
 | filePath | The relative file path of the file to return todo items for. |
+
+<a name="getTodoBatchesSync"></a>
+
+## getTodoBatchesSync(lintResults, existing) ⇒
+Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).
+
+**Kind**: global function  
+**Returns**: - A [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
+
+| Param | Description |
+| --- | --- |
+| lintResults | The linting data for all violations. |
+| existing | Existing todo lint data. |
 
 <a name="getTodoBatches"></a>
 
@@ -216,12 +306,25 @@ Reads todo files in the .lint-todo directory for a specific filePath.
 Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).
 
 **Kind**: global function  
-**Returns**: - A Promise resolving to a [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
+**Returns**: - A Promise that resolves to a [Map](Map) of [FilePath](FilePath)/[TodoData](TodoData).  
 
 | Param | Description |
 | --- | --- |
 | lintResults | The linting data for all violations. |
 | existing | Existing todo lint data. |
+
+<a name="applyTodoChangesSync"></a>
+
+## applyTodoChangesSync(todoStorageDir, add, remove)
+Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
+
+**Kind**: global function  
+
+| Param | Description |
+| --- | --- |
+| todoStorageDir | The .lint-todo storage directory. |
+| add | Batch of todos to add. |
+| remove | Batch of todos to remove. |
 
 <a name="applyTodoChanges"></a>
 

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -2,13 +2,16 @@ import { existsSync, readdir, statSync } from 'fs-extra';
 import { posix } from 'path';
 import {
   buildTodoData,
-  writeTodos,
+  ensureTodoStorageDir,
+  ensureTodoStorageDirSync,
   getTodoBatches,
+  getTodoBatchesSync,
   todoDirFor,
   todoFileNameFor,
   todoFilePathFor,
   todoStorageDirExists,
-  ensureTodoStorageDir,
+  writeTodos,
+  writeTodosSync,
 } from '../src';
 import { LintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
@@ -49,6 +52,12 @@ describe('io', () => {
   describe('todoStorageDirExists', () => {
     it('returns false when directory does not exist', async () => {
       expect(todoStorageDirExists(tmp)).toEqual(false);
+    });
+
+    it('returns true when directory exists sync', async () => {
+      ensureTodoStorageDirSync(tmp);
+
+      expect(todoStorageDirExists(tmp)).toEqual(true);
     });
 
     it('returns true when directory exists', async () => {
@@ -101,6 +110,180 @@ describe('io', () => {
       const dir2 = todoFilePathFor(TODO_DATA);
 
       expect(dir1).toEqual(dir2);
+    });
+  });
+
+  describe('writeTodosSync', () => {
+    it("creates .lint-todo directory if one doesn't exist", async () => {
+      const todoDir = writeTodosSync(tmp, []);
+
+      expect(existsSync(todoDir)).toEqual(true);
+    });
+
+    it("doesn't write files when no todos provided", async () => {
+      const todoDir = writeTodosSync(tmp, []);
+
+      expect(await readFiles(todoDir)).toHaveLength(0);
+    });
+
+    it('generates todos when todos provided', async () => {
+      const todoDir = writeTodosSync(tmp, getFixture('eslint-with-errors', tmp));
+
+      expect(await readFiles(todoDir)).toHaveLength(18);
+    });
+
+    it("generates todos only if previous todo doesn't exist", async () => {
+      const initialTodos: LintResult[] = [
+        {
+          filePath: '{{path}}/app/controllers/settings.js',
+          messages: [
+            {
+              ruleId: 'no-prototype-builtins',
+              severity: 2,
+              message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+              line: 25,
+              column: 21,
+              nodeType: 'CallExpression',
+              messageId: 'prototypeBuildIn',
+              endLine: 25,
+              endColumn: 35,
+            },
+            {
+              ruleId: 'no-prototype-builtins',
+              severity: 2,
+              message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+              line: 26,
+              column: 19,
+              nodeType: 'CallExpression',
+              messageId: 'prototypeBuildIn',
+              endLine: 26,
+              endColumn: 33,
+            },
+          ],
+          errorCount: 2,
+          warningCount: 0,
+          fixableErrorCount: 0,
+          fixableWarningCount: 0,
+          source: '',
+          usedDeprecatedRules: [],
+        },
+      ];
+
+      const todoDir = writeTodosSync(tmp, updatePaths<LintResult>(tmp, initialTodos));
+
+      const initialFiles = await readFiles(todoDir);
+
+      expect(initialFiles).toHaveLength(2);
+
+      const initialFileStats = initialFiles.map((file) => {
+        return {
+          fileName: file,
+          ctime: statSync(posix.join(todoDir, file)).ctime,
+        };
+      });
+
+      writeTodosSync(tmp, getFixture('eslint-with-errors', tmp));
+
+      const subsequentFiles = await readFiles(todoDir);
+
+      expect(subsequentFiles).toHaveLength(18);
+
+      initialFileStats.forEach((initialFileStat) => {
+        const subsequentFile = statSync(posix.join(todoDir, initialFileStat.fileName));
+
+        expect(subsequentFile.ctime).toEqual(initialFileStat.ctime);
+      });
+    });
+
+    it('removes old todos if todos no longer contains violations', async () => {
+      const fixture = getFixture('eslint-with-errors', tmp);
+      const todoDir = writeTodosSync(tmp, fixture);
+      const initialFiles = await readFiles(todoDir);
+
+      expect(initialFiles).toHaveLength(18);
+
+      const firstHalf = fixture.slice(0, 3);
+      const secondHalf = fixture.slice(3, fixture.length);
+
+      writeTodosSync(tmp, firstHalf);
+
+      const subsequentFiles = await readFiles(todoDir);
+
+      expect(subsequentFiles).toHaveLength(7);
+
+      buildTodoData(tmp, secondHalf).forEach((todoDatum) => {
+        expect(!existsSync(posix.join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(
+          true
+        );
+      });
+    });
+  });
+
+  describe('writeTodosSync for single file', () => {
+    it('generates todos for a specific filePath', async () => {
+      const todoDir = writeTodosSync(
+        tmp,
+        getFixture('single-file-todo', tmp),
+        'app/controllers/settings.js'
+      );
+
+      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
+        ]
+      `);
+    });
+
+    it('updates todos for a specific filePath', async () => {
+      const todoDir = writeTodosSync(
+        tmp,
+        getFixture('single-file-todo', tmp),
+        'app/controllers/settings.js'
+      );
+
+      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
+        ]
+      `);
+
+      writeTodosSync(
+        tmp,
+        getFixture('single-file-todo-updated', tmp),
+        'app/controllers/settings.js'
+      );
+
+      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/ee492fc4.json",
+        ]
+      `);
+    });
+
+    it('deletes todos for a specific filePath', async () => {
+      const todoDir = writeTodosSync(
+        tmp,
+        getFixture('single-file-todo', tmp),
+        'app/controllers/settings.js'
+      );
+
+      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
+        ]
+      `);
+
+      writeTodosSync(tmp, getFixture('single-file-no-errors', tmp), 'app/controllers/settings.js');
+
+      expect(await readFiles(todoDir)).toHaveLength(0);
     });
   });
 
@@ -203,7 +386,9 @@ describe('io', () => {
       expect(subsequentFiles).toHaveLength(7);
 
       buildTodoData(tmp, secondHalf).forEach((todoDatum) => {
-        expect(!existsSync(posix.join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(true);
+        expect(!existsSync(posix.join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(
+          true
+        );
       });
     });
   });
@@ -240,7 +425,11 @@ describe('io', () => {
         ]
       `);
 
-      await writeTodos(tmp, getFixture('single-file-todo-updated', tmp), 'app/controllers/settings.js');
+      await writeTodos(
+        tmp,
+        getFixture('single-file-todo-updated', tmp),
+        'app/controllers/settings.js'
+      );
 
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
@@ -266,15 +455,85 @@ describe('io', () => {
         ]
       `);
 
-      await writeTodos(tmp, getFixture('single-file-no-errors', tmp), 'app/controllers/settings.js');
+      await writeTodos(
+        tmp,
+        getFixture('single-file-no-errors', tmp),
+        'app/controllers/settings.js'
+      );
 
       expect(await readFiles(todoDir)).toHaveLength(0);
     });
   });
 
+  describe('getTodoBatchesSync', () => {
+    it('creates items to add', async () => {
+      const [add] = getTodoBatchesSync(
+        buildTodoData(tmp, getFixture('new-batches', tmp)),
+        new Map()
+      );
+
+      expect([...add.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+        ]
+      `);
+    });
+
+    it('creates items to delete', async () => {
+      const [, remove] = getTodoBatchesSync(
+        new Map(),
+        buildTodoData(tmp, getFixture('new-batches', tmp))
+      );
+
+      expect([...remove.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+        ]
+      `);
+    });
+
+    it('creates all batches', async () => {
+      const [add, remove, stable] = getTodoBatchesSync(
+        buildTodoData(tmp, getFixture('new-batches', tmp)),
+        buildTodoData(tmp, getFixture('existing-batches', tmp))
+      );
+
+      expect([...add.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+        ]
+      `);
+      expect([...remove.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "07d3818b8afefcdd7db6d52743309fdbb85313f0/66256fb7",
+          "07d3818b8afefcdd7db6d52743309fdbb85313f0/8fd35486",
+        ]
+      `);
+      expect([...stable.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+        ]
+      `);
+    });
+  });
+
   describe('getTodoBatches', () => {
     it('creates items to add', async () => {
-      const [add] = await getTodoBatches(buildTodoData(tmp, getFixture('new-batches', tmp)), new Map());
+      const [add] = await getTodoBatches(
+        buildTodoData(tmp, getFixture('new-batches', tmp)),
+        new Map()
+      );
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { _buildTodoDatum, buildTodoData } from './builders';
 export {
-  ensureTodoStorageDir,
   applyTodoChanges,
+  ensureTodoStorageDir,
   getTodoStorageDirPath,
   getTodoBatches,
   todoStorageDirExists,
@@ -11,6 +11,12 @@ export {
   readTodos,
   readTodosForFilePath,
   writeTodos,
+  applyTodoChangesSync,
+  ensureTodoStorageDirSync,
+  getTodoBatchesSync,
+  readTodosSync,
+  readTodosForFilePathSync,
+  writeTodosSync,
 } from './io';
 
 export * from './types';

--- a/src/io.ts
+++ b/src/io.ts
@@ -142,7 +142,7 @@ export function writeTodosSync(
  * @param lintResults - The raw linting data.
  * @param filePath - The relative file path of the file to update violations for.
  * @param daysToDecay - An object containing the warn or error days, in integers.
- * @returns - The todo storage directory path.
+ * @returns - A promise that resolves to the todo storage directory path.
  */
 export async function writeTodos(
   baseDir: string,
@@ -191,7 +191,7 @@ export function readTodosSync(baseDir: string): Map<FilePath, TodoData> {
  * Reads all todo files in the .lint-todo directory.
  *
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
- * @returns - A Promise resolving to a {@link Map} of {@link FilePath}/{@link TodoData}.
+ * @returns - A Promise that resolves to a {@link Map} of {@link FilePath}/{@link TodoData}.
  */
 export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData>> {
   const map = new Map();
@@ -249,7 +249,7 @@ export function readTodosForFilePathSync(
  *
  * @param todoStorageDir - The .lint-todo storage directory.
  * @param filePath - The relative file path of the file to return todo items for.
- * @returns - A Promise resolving to a {@link Map} of {@link FilePath}/{@link TodoData}.
+ * @returns - A Promise that resolves to a {@link Map} of {@link FilePath}/{@link TodoData}.
  */
 export async function readTodosForFilePath(
   baseDir: string,
@@ -317,7 +317,7 @@ export function getTodoBatchesSync(
  *
  * @param lintResults - The linting data for all violations.
  * @param existing - Existing todo lint data.
- * @returns - A Promise resolving to a {@link Map} of {@link FilePath}/{@link TodoData}.
+ * @returns - A Promise that resolves to a {@link Map} of {@link FilePath}/{@link TodoData}.
  */
 export async function getTodoBatches(
   lintResults: Map<FilePath, TodoData>,


### PR DESCRIPTION
The `eslint` formatter implementation requires sync APIs (for now). This PR adds related sync APIs in addition to keeping the async ones.