### PR TITLE
Adding JSON date reviver to deserialize dates

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -12,6 +12,8 @@ import {
   todoStorageDirExists,
   writeTodos,
   writeTodosSync,
+  readTodosSync,
+  readTodos,
 } from '../src';
 import { LintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
@@ -121,15 +123,16 @@ describe('io', () => {
     });
 
     it("doesn't write files when no todos provided", async () => {
-      const todoDir = writeTodosSync(tmp, []);
+      writeTodosSync(tmp, []);
 
-      expect(await readFiles(todoDir)).toHaveLength(0);
+      expect(readTodosSync(tmp).size).toEqual(0);
     });
 
     it('generates todos when todos provided', async () => {
-      const todoDir = writeTodosSync(tmp, getFixture('eslint-with-errors', tmp));
+      writeTodosSync(tmp, getFixture('eslint-with-errors', tmp));
 
-      expect(await readFiles(todoDir)).toHaveLength(18);
+      const todos = readTodosSync(tmp);
+      expect(todos.size).toEqual(18);
     });
 
     it("generates todos only if previous todo doesn't exist", async () => {
@@ -219,6 +222,23 @@ describe('io', () => {
     });
   });
 
+  describe('readTodosSync', () => {
+    it('deserializes dates back to Date objects', () => {
+      writeTodosSync(tmp, getFixture('eslint-single-error', tmp), undefined, {
+        warn: 5,
+        error: 10,
+      });
+
+      const todos = readTodosSync(tmp);
+      const todo = todos.values().next().value;
+
+      expect(todos.size).toEqual(1);
+      expect(todo.createdDate).toBeInstanceOf(Date);
+      expect(todo.warnDate).toBeInstanceOf(Date);
+      expect(todo.errorDate).toBeInstanceOf(Date);
+    });
+  });
+
   describe('writeTodosSync for single file', () => {
     it('generates todos for a specific filePath', async () => {
       const todoDir = writeTodosSync(
@@ -295,15 +315,15 @@ describe('io', () => {
     });
 
     it("doesn't write files when no todos provided", async () => {
-      const todoDir = await writeTodos(tmp, []);
+      await writeTodos(tmp, []);
 
-      expect(await readFiles(todoDir)).toHaveLength(0);
+      expect((await readTodos(tmp)).size).toEqual(0);
     });
 
     it('generates todos when todos provided', async () => {
-      const todoDir = await writeTodos(tmp, getFixture('eslint-with-errors', tmp));
+      await writeTodos(tmp, getFixture('eslint-with-errors', tmp));
 
-      expect(await readFiles(todoDir)).toHaveLength(18);
+      expect((await readTodos(tmp)).size).toEqual(18);
     });
 
     it("generates todos only if previous todo doesn't exist", async () => {
@@ -390,6 +410,23 @@ describe('io', () => {
           true
         );
       });
+    });
+  });
+
+  describe('readTodos', () => {
+    it('deserializes dates back to Date objects', async () => {
+      await writeTodos(tmp, getFixture('eslint-single-error', tmp), undefined, {
+        warn: 5,
+        error: 10,
+      });
+
+      const todos = await readTodos(tmp);
+      const todo = todos.values().next().value;
+
+      expect(todos.size).toEqual(1);
+      expect(todo.createdDate).toBeInstanceOf(Date);
+      expect(todo.warnDate).toBeInstanceOf(Date);
+      expect(todo.errorDate).toBeInstanceOf(Date);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "fs-extra": "^9.0.1",
+    "json-date-parser": "^1.0.1",
     "slash": "^3.0.0"
   },
   "devDependencies": {

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { posix } from 'path';
+import { jsonDateParser } from 'json-date-parser';
 import {
   ensureDir,
   existsSync,
@@ -179,7 +180,9 @@ export function readTodosSync(baseDir: string): Map<FilePath, TodoData> {
     const fileNames = readdirSync(posix.join(todoStorageDir, todoFileDir));
 
     for (const fileName of fileNames) {
-      const todo = readJSONSync(posix.join(todoStorageDir, todoFileDir, fileName));
+      const todo = readJSONSync(posix.join(todoStorageDir, todoFileDir, fileName), {
+        reviver: jsonDateParser,
+      });
       map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
     }
   }
@@ -202,7 +205,9 @@ export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData
     const fileNames = await readdir(posix.join(todoStorageDir, todoFileDir));
 
     for (const fileName of fileNames) {
-      const todo = await readJSON(posix.join(todoStorageDir, todoFileDir, fileName));
+      const todo = await readJSON(posix.join(todoStorageDir, todoFileDir, fileName), {
+        reviver: jsonDateParser,
+      });
       map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
     }
   }
@@ -230,7 +235,9 @@ export function readTodosForFilePathSync(
     const fileNames = readdirSync(todoFilePathDir);
 
     for (const fileName of fileNames) {
-      const todo = readJSONSync(posix.join(todoFilePathDir, fileName));
+      const todo = readJSONSync(posix.join(todoFilePathDir, fileName), {
+        reviver: jsonDateParser,
+      });
       map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
     }
   } catch (error) {
@@ -264,7 +271,9 @@ export async function readTodosForFilePath(
     const fileNames = await readdir(todoFilePathDir);
 
     for (const fileName of fileNames) {
-      const todo = await readJSON(posix.join(todoFilePathDir, fileName));
+      const todo = await readJSON(posix.join(todoFilePathDir, fileName), {
+        reviver: jsonDateParser,
+      });
       map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
     }
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,6 +3936,11 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-date-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-date-parser/-/json-date-parser-1.0.1.tgz#b70eb47c898f3b16643ad63ffb8d9620fd784f85"
+  integrity sha1-tw60fImPOxZkOtY/+42WIP14T4U=
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"


### PR DESCRIPTION
The current implementation of todos reads dates as strings. This change ensures they're correctly deserialized back to `Date` objects.