### PR TITLE
Adding overloads for writeTodos[Sync]

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -224,7 +224,7 @@ describe('io', () => {
 
   describe('readTodosSync', () => {
     it('deserializes dates back to Date objects', () => {
-      writeTodosSync(tmp, getFixture('eslint-single-error', tmp), undefined, {
+      writeTodosSync(tmp, getFixture('eslint-single-error', tmp), {
         warn: 5,
         error: 10,
       });
@@ -415,7 +415,7 @@ describe('io', () => {
 
   describe('readTodos', () => {
     it('deserializes dates back to Date objects', async () => {
-      await writeTodos(tmp, getFixture('eslint-single-error', tmp), undefined, {
+      await writeTodos(tmp, getFixture('eslint-single-error', tmp), {
         warn: 5,
         error: 10,
       });

--- a/src/io.ts
+++ b/src/io.ts
@@ -112,12 +112,36 @@ export function todoFileNameFor(todoData: TodoData): string {
  * @param daysToDecay - An object containing the warn or error days, in integers.
  * @returns - The todo storage directory path.
  */
+export function writeTodosSync(baseDir: string, lintResults: LintResult[]): string;
 export function writeTodosSync(
   baseDir: string,
   lintResults: LintResult[],
-  filePath = '',
+  filePath: string
+): string;
+export function writeTodosSync(
+  baseDir: string,
+  lintResults: LintResult[],
+  daysToDecay: DaysToDecay
+): string;
+export function writeTodosSync(
+  baseDir: string,
+  lintResults: LintResult[],
+  filePath: string | DaysToDecay,
+  daysToDecay?: DaysToDecay
+): string;
+export function writeTodosSync(
+  baseDir: string,
+  lintResults: LintResult[],
+  filePath?: string | DaysToDecay,
   daysToDecay?: DaysToDecay
 ): string {
+  if (typeof filePath === 'object') {
+    daysToDecay = filePath;
+    filePath = '';
+  } else if (typeof filePath === 'undefined') {
+    filePath = '';
+  }
+
   const todoStorageDir: string = ensureTodoStorageDirSync(baseDir);
   const existing: Map<FilePath, TodoData> = filePath
     ? readTodosForFilePathSync(baseDir, filePath)
@@ -145,12 +169,36 @@ export function writeTodosSync(
  * @param daysToDecay - An object containing the warn or error days, in integers.
  * @returns - A promise that resolves to the todo storage directory path.
  */
+export async function writeTodos(baseDir: string, lintResults: LintResult[]): Promise<string>;
 export async function writeTodos(
   baseDir: string,
   lintResults: LintResult[],
-  filePath = '',
+  filePath: string
+): Promise<string>;
+export async function writeTodos(
+  baseDir: string,
+  lintResults: LintResult[],
+  daysToDecay: DaysToDecay
+): Promise<string>;
+export async function writeTodos(
+  baseDir: string,
+  lintResults: LintResult[],
+  filePath: string | DaysToDecay,
+  daysToDecay?: DaysToDecay
+): Promise<string>;
+export async function writeTodos(
+  baseDir: string,
+  lintResults: LintResult[],
+  filePath?: string | DaysToDecay,
   daysToDecay?: DaysToDecay
 ): Promise<string> {
+  if (typeof filePath === 'object') {
+    daysToDecay = filePath;
+    filePath = '';
+  } else if (typeof filePath === 'undefined') {
+    filePath = '';
+  }
+
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const existing: Map<FilePath, TodoData> = filePath
     ? await readTodosForFilePath(baseDir, filePath)


### PR DESCRIPTION
Adds necessary function overloads to `writeTodos[Sync]` implementation, with correct parameter shifting.