### PR TITLE
Changes the way consumers can provide createdDate

### DIFF
--- a/__tests__/builders-test.ts
+++ b/__tests__/builders-test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ESLint, Linter } from 'eslint';
 import { differenceInDays } from 'date-fns';
-import { _buildTodoDatum, buildTodoData, _setCreatedDate } from '../src';
+import { _buildTodoDatum, buildTodoData } from '../src';
 import { TemplateLintMessage, TemplateLintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
 import { updatePath } from './__utils__/update-path';
@@ -108,14 +108,14 @@ describe('builders', () => {
     });
 
     it('can build todo data with a custom createdDate', () => {
-      _setCreatedDate(new Date(2015, 1, 23));
+      process.env.TODO_CREATED_DATE = new Date(2015, 1, 23).toJSON();
 
       const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), { warn: 30 });
       const todoDatum: TodoData = todoData.values().next().value;
 
       expect(todoDatum.createdDate).toEqual(new Date(2015, 1, 23));
 
-      _setCreatedDate();
+      process.env.TODO_CREATED_DATE = '';
     });
   });
 

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -3,8 +3,6 @@ import slash = require('slash');
 import { todoFilePathFor } from './io';
 import { DaysToDecay, FilePath, LintMessage, LintResult, TodoData } from './types';
 
-let _createdDate: Date | undefined;
-
 /**
  * Adapts a list of {@link LintResult} to a map of {@link FilePath}, {@link TodoData}.
  *
@@ -76,11 +74,6 @@ export function _buildTodoDatum(
   return todoDatum;
 }
 
-// eslint-disable-next-line unicorn/no-useless-undefined
-export function _setCreatedDate(createdDate: Date | undefined = undefined): void {
-  _createdDate = createdDate;
-}
-
 function getEngine(result: LintResult) {
   return result.filePath.endsWith('.js') ? 'eslint' : 'ember-template-lint';
 }
@@ -95,8 +88,8 @@ function getRuleId(message: any) {
 }
 
 function getCreatedDate(): Date {
-  if (_createdDate !== undefined) {
-    return _createdDate;
+  if (process.env.TODO_CREATED_DATE) {
+    return new Date(process.env.TODO_CREATED_DATE);
   }
 
   return new Date();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { _buildTodoDatum, buildTodoData, _setCreatedDate } from './builders';
+export { _buildTodoDatum, buildTodoData } from './builders';
 export {
   applyTodoChanges,
   ensureTodoStorageDir,


### PR DESCRIPTION
This PR fixes the way we provide a static `createdDate` to todos. The [previous PR](https://github.com/ember-template-lint/ember-template-lint-todo-utils/pull/38) that added a test helper that allowed you to set a `createdDate` in module scope seemed reasonable, but didn't work as intended. 

While it's fine to provide the fake dates this way, the two consuming libraries, `@scalvert/eslint-formatter-todo` and `ember-template-lint`, both execute the linting executables via execa when testing. Due to this, it wasn't feasible to provide the `createdDate` to the module scope of that process' todo-utils. Therefore, it was necessary to provide this date via another means. 

Since execa allows you to pass environment variables to its spawned process, this seemed the best approach. As such, this PR adds the ability to set the static `createdDate` via a `TODO_CREATED_DATE` environment variable to the executed process.