### PR TITLE
Moves @types/eslint to deps from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
+    "@types/eslint": "^7.2.3",
     "fs-extra": "^9.0.1",
     "json-date-parser": "^1.0.1",
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@types/eslint": "^7.2.3",
     "@types/fs-extra": "^9.0.1",
     "@types/slash": "^3.0.0",
     "@types/tmp": "^0.2.0",


### PR DESCRIPTION
Typescript consumers require the `@types/eslint` types to be published with this package to avoid them having to install those types themselves. This PR moves that package from devDependencies to dependencies to facilitate this.