### PR TITLE
Fixing error message for invalid config values

### DIFF
--- a/__tests__/get-todo-config-test.ts
+++ b/__tests__/get-todo-config-test.ts
@@ -148,13 +148,13 @@ describe('get-todo-config', () => {
 
   it('throws if warn is equal to error', () => {
     expect(() => getTodoConfig(project.baseDir, { warn: 5, error: 5 })).toThrow(
-      'The `lintTodo` configuration in the package.json contains invalid values. The `warn` value must be less than the `error` value.'
+      'The provided TODO configuration contains invalid values. The `warn` value (5) must be less than the `error` value (5).'
     );
   });
 
   it('throws if warn is greater than to error', () => {
     expect(() => getTodoConfig(project.baseDir, { warn: 10, error: 5 })).toThrow(
-      'The `lintTodo` configuration in the package.json contains invalid values. The `warn` value must be less than the `error` value.'
+      'The provided TODO configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
     );
   });
 });

--- a/src/get-todo-config.ts
+++ b/src/get-todo-config.ts
@@ -43,7 +43,7 @@ export function getTodoConfig(
     mergedConfig.warn >= mergedConfig.error
   ) {
     throw new Error(
-      'The `lintTodo` configuration in the package.json contains invalid values. The `warn` value must be less than the `error` value.'
+      `The provided TODO configuration contains invalid values. The \`warn\` value (${mergedConfig.warn}) must be less than the \`error\` value (${mergedConfig.error}).`
     );
   }
 


### PR DESCRIPTION
The error message for when the `warn` value is greater than or equal to the `error` value specifies that it's related to the `package.json` configuration only, when it in fact works for all. This PR fixes that error to be more accurate.