### PR TITLE
Ensures empty todo directories are deleted

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -288,6 +288,7 @@ describe('io', () => {
       writeTodosSync(tmp, getFixture('single-file-no-errors', tmp), 'app/controllers/settings.js');
 
       expect(await readFiles(todoDir)).toHaveLength(0);
+      expect(await readdir(todoDir)).toHaveLength(0);
     });
   });
 
@@ -466,6 +467,7 @@ describe('io', () => {
       );
 
       expect(await readFiles(todoDir)).toHaveLength(0);
+      expect(await readdir(todoDir)).toHaveLength(0);
     });
   });
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -12,6 +12,8 @@ import {
   readJSONSync,
   writeJsonSync,
   unlinkSync,
+  rmdirSync,
+  rmdir,
 } from 'fs-extra';
 import { buildTodoData } from './builders';
 import { TodoConfig, FilePath, LintResult, TodoData } from './types';
@@ -414,7 +416,14 @@ export function applyTodoChangesSync(
   }
 
   for (const [fileHash] of remove) {
+    const { dir } = posix.parse(fileHash);
+    const todoDir = posix.join(todoStorageDir, dir);
+
     unlinkSync(posix.join(todoStorageDir, `${fileHash}.json`));
+
+    if (readdirSync(todoDir).length === 0) {
+      rmdirSync(todoDir);
+    }
   }
 }
 
@@ -438,6 +447,13 @@ export async function applyTodoChanges(
   }
 
   for (const [fileHash] of remove) {
+    const { dir } = posix.parse(fileHash);
+    const todoDir = posix.join(todoStorageDir, dir);
+
     await unlink(posix.join(todoStorageDir, `${fileHash}.json`));
+
+    if ((await readdir(todoDir)).length === 0) {
+      await rmdir(todoDir);
+    }
   }
 }


### PR DESCRIPTION
Relates to https://github.com/ember-template-lint/ember-template-lint/issues/1684. If a directory contains no files, we ensure it's deleted. While this does introduce some extra I/O for the removal and potential recreation of the same directory, this does remove ghost directories remaining.