### PR TITLE
Standardize casing for todos

### DIFF
--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -149,13 +149,13 @@ describe('todo-config', () => {
 
     it('throws if warn is equal to error', () => {
       expect(() => getTodoConfig(project.baseDir, { warn: 5, error: 5 })).toThrow(
-        'The provided TODO configuration contains invalid values. The `warn` value (5) must be less than the `error` value (5).'
+        'The provided todo configuration contains invalid values. The `warn` value (5) must be less than the `error` value (5).'
       );
     });
 
     it('throws if warn is greater than to error', () => {
       expect(() => getTodoConfig(project.baseDir, { warn: 10, error: 5 })).toThrow(
-        'The provided TODO configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
+        'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
       );
     });
   });

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -111,7 +111,7 @@ Upon first generation of the list of todo lint rules, any existing lint violatio
   - writes `todo` violations to disc, one file per violation
   - ensures old `todo` violation files are removed
 
-#### Proposed Schema for TODO violation data
+#### Proposed Schema for todo violation data
 
 ```ts
 interface TodoData {

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -46,7 +46,7 @@ export function getTodoConfig(
     mergedConfig.warn >= mergedConfig.error
   ) {
     throw new Error(
-      `The provided TODO configuration contains invalid values. The \`warn\` value (${mergedConfig.warn}) must be less than the \`error\` value (${mergedConfig.error}).`
+      `The provided todo configuration contains invalid values. The \`warn\` value (${mergedConfig.warn}) must be less than the \`error\` value (${mergedConfig.error}).`
     );
   }
 


### PR DESCRIPTION
We've been using `TODO` and `todo`, depending on the situation. This PR standardizes us using `todo`. 