### PR TITLE
Adding ensureTodoConfig to write default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ have a todo lint violation.</p>
 Config values can be present in</p>
 <p>The package.json</p>
 </dd>
+<dt><a href="#ensureTodoConfig">ensureTodoConfig(baseDir)</a></dt>
+<dd><p>Ensures that a valid todo config exists in the project by writing one to the package.json
+if we&#39;re invoking the todos functionality for the first time (there is no .lint-todo directory).</p>
+</dd>
 <dt><a href="#writeTodoConfig">writeTodoConfig(baseDir, todoConfig)</a></dt>
 <dd><p>Writes a todo config to the package.json located at the provided baseDir.</p>
 </dd>
@@ -387,6 +391,18 @@ Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`)
 
 Passed in directly, such as from command line options.
 	- Passed in options override both env vars and package.json config
+<a name="ensureTodoConfig"></a>
+
+## ensureTodoConfig(baseDir)
+Ensures that a valid todo config exists in the project by writing one to the package.json
+if we're invoking the todos functionality for the first time (there is no .lint-todo directory).
+
+**Kind**: global function  
+
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the project's package.json. |
+
 <a name="writeTodoConfig"></a>
 
 ## writeTodoConfig(baseDir, todoConfig)

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -205,7 +205,7 @@ describe('todo-config', () => {
       expect(pkg).toEqual(originalPkg);
     });
 
-    it('does changes package.json if lintTodo directory not present', () => {
+    it('does change package.json if lintTodo directory not present', () => {
       ensureTodoConfig(project.baseDir);
 
       const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -1,7 +1,8 @@
 import { unlink, readFileSync, writeFileSync } from 'fs-extra';
 import { join } from 'path';
-import { getTodoConfig, writeTodoConfig } from '../src';
+import { getTodoConfig, writeTodoConfig, ensureTodoStorageDirSync } from '../src';
 import { FakeProject } from './__utils__/fake-project';
+import { ensureTodoConfig } from '../src/todo-config';
 
 describe('todo-config', () => {
   let project: FakeProject;
@@ -157,6 +158,62 @@ describe('todo-config', () => {
       expect(() => getTodoConfig(project.baseDir, { warn: 10, error: 5 })).toThrow(
         'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
       );
+    });
+  });
+
+  describe('ensureTodoConfig', () => {
+    it('does not change package.json if lintTodo directory present', () => {
+      ensureTodoStorageDirSync(project.baseDir);
+
+      const originalPkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      ensureTodoConfig(project.baseDir);
+
+      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      expect(pkg).toEqual(originalPkg);
+    });
+
+    it('does not change package.json if todo config already present', () => {
+      ensureTodoStorageDirSync(project.baseDir);
+
+      writeTodoConfig(project.baseDir, {
+        warn: 10,
+        error: 20,
+      });
+
+      const originalPkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      ensureTodoConfig(project.baseDir);
+
+      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      expect(pkg).toEqual(originalPkg);
+    });
+
+    it('does changes package.json if lintTodo directory not present', () => {
+      ensureTodoConfig(project.baseDir);
+
+      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      expect(pkg).toMatchInlineSnapshot(`
+        "{
+          \\"name\\": \\"fake-project\\",
+          \\"version\\": \\"0.0.0\\",
+          \\"keywords\\": [],
+          \\"license\\": \\"MIT\\",
+          \\"description\\": \\"Fake project\\",
+          \\"repository\\": \\"http://fakerepo.com\\",
+          \\"dependencies\\": {},
+          \\"devDependencies\\": {},
+          \\"lintTodo\\": {
+            \\"decayDays\\": {
+              \\"warn\\": 30,
+              \\"error\\": 60
+            }
+          }
+        }"
+      `);
     });
   });
 

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -191,6 +191,20 @@ describe('todo-config', () => {
       expect(pkg).toEqual(originalPkg);
     });
 
+    it('does not change package.json if todo config is empty object', () => {
+      ensureTodoStorageDirSync(project.baseDir);
+
+      writeTodoConfig(project.baseDir, {});
+
+      const originalPkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      ensureTodoConfig(project.baseDir);
+
+      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
+
+      expect(pkg).toEqual(originalPkg);
+    });
+
     it('does changes package.json if lintTodo directory not present', () => {
       ensureTodoConfig(project.baseDir);
 

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { TodoConfig } from './types';
-import { readFileSync, writeFileSync } from 'fs-extra';
+import { readFileSync, writeFileSync, readJsonSync } from 'fs-extra';
+import { todoStorageDirExists } from './io';
 
 const DETECT_TRAILING_WHITESPACE = /\s+$/;
 
@@ -51,6 +52,25 @@ export function getTodoConfig(
   }
 
   return mergedConfig;
+}
+
+/**
+ * Ensures that a valid todo config exists in the project by writing one to the package.json
+ * if we're invoking the todos functionality for the first time (there is no .lint-todo directory).
+ *
+ * @param baseDir - The base directory that contains the project's package.json.
+ */
+export function ensureTodoConfig(baseDir: string): void {
+  if (!todoStorageDirExists(baseDir)) {
+    const pkg = readJsonSync(join(baseDir, 'package.json'));
+
+    if (!pkg.lintTodo) {
+      writeTodoConfig(baseDir, {
+        warn: 30,
+        error: 60,
+      });
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Adds new `ensureTodoConfig` directory.

```ts
export function ensureTodoConfig(baseDir: string): void;
```

This allows us to provide this behavior in the respective consuming packages, `@scalvert/eslint-formatter-todo` and `ember-template-lint`.

