### PR TITLE
Changed signature of writeTodos to allow additional param for skipping removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ serializing the contents to disc.</p>
 <dt><a href="#todoFileNameFor">todoFileNameFor(todoData)</a> ⇒</dt>
 <dd><p>Generates a unique filename for a todo lint data.</p>
 </dd>
-<dt><a href="#writeTodosSync">writeTodosSync(baseDir, lintResults, filePath, todoConfig)</a> ⇒</dt>
+<dt><a href="#writeTodosSync">writeTodosSync(baseDir, lintResults, options)</a> ⇒</dt>
 <dd><p>Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.</p>
 <p>Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.</p>
 </dd>
-<dt><a href="#writeTodos">writeTodos(baseDir, lintResults, filePath, todoConfig)</a> ⇒</dt>
+<dt><a href="#writeTodos">writeTodos(baseDir, lintResults, options)</a> ⇒</dt>
 <dd><p>Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.</p>
 <p>Given a list of todo lint violations, this function will also delete existing files that no longer
@@ -220,7 +220,7 @@ Generates a unique filename for a todo lint data.
 
 <a name="writeTodosSync"></a>
 
-## writeTodosSync(baseDir, lintResults, filePath, todoConfig) ⇒
+## writeTodosSync(baseDir, lintResults, options) ⇒
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
@@ -234,12 +234,11 @@ have a todo lint violation.
 | --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 | lintResults | The raw linting data. |
-| filePath | The relative file path of the file to update violations for. |
-| todoConfig | An object containing the warn or error days, in integers. |
+| options | An object containing write options. |
 
 <a name="writeTodos"></a>
 
-## writeTodos(baseDir, lintResults, filePath, todoConfig) ⇒
+## writeTodos(baseDir, lintResults, options) ⇒
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
@@ -253,8 +252,7 @@ have a todo lint violation.
 | --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 | lintResults | The raw linting data. |
-| filePath | The relative file path of the file to update violations for. |
-| todoConfig | An object containing the warn or error days, in integers. |
+| options | An object containing write options. |
 
 <a name="readTodosSync"></a>
 

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -230,16 +230,35 @@ describe('io', () => {
         );
       });
     });
+
+    it('does not remove old todos if todos no longer contains violations if skipRemoval is true', async () => {
+      const fixture = getFixture('eslint-with-errors', tmp);
+      const todoDir = getTodoStorageDirPath(tmp);
+
+      const [added] = writeTodosSync(tmp, fixture);
+
+      const initialFiles = await readFiles(todoDir);
+
+      expect(added).toEqual(18);
+      expect(initialFiles).toHaveLength(18);
+
+      const firstHalf = fixture.slice(0, 3);
+
+      const [, removed] = writeTodosSync(tmp, firstHalf, { skipRemoval: true });
+
+      const subsequentFiles = await readFiles(todoDir);
+
+      expect(removed).toEqual(0);
+      expect(subsequentFiles).toHaveLength(18);
+    });
   });
 
   describe('writeTodosSync for single file', () => {
     it('generates todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(
-        tmp,
-        getFixture('single-file-todo', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added] = writeTodosSync(tmp, getFixture('single-file-todo', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added).toEqual(3);
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
@@ -253,11 +272,9 @@ describe('io', () => {
 
     it('updates todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(
-        tmp,
-        getFixture('single-file-todo', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added] = writeTodosSync(tmp, getFixture('single-file-todo', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added).toEqual(3);
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
@@ -268,11 +285,9 @@ describe('io', () => {
         ]
       `);
 
-      const [added2, removed2] = writeTodosSync(
-        tmp,
-        getFixture('single-file-todo-updated', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added2, removed2] = writeTodosSync(tmp, getFixture('single-file-todo-updated', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added2).toEqual(1);
       expect(removed2).toEqual(1);
@@ -287,11 +302,9 @@ describe('io', () => {
 
     it('deletes todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(
-        tmp,
-        getFixture('single-file-todo', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added] = writeTodosSync(tmp, getFixture('single-file-todo', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added).toEqual(3);
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
@@ -302,11 +315,9 @@ describe('io', () => {
         ]
       `);
 
-      const [added2, removed2] = writeTodosSync(
-        tmp,
-        getFixture('single-file-no-errors', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added2, removed2] = writeTodosSync(tmp, getFixture('single-file-no-errors', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added2).toEqual(0);
       expect(removed2).toEqual(3);
@@ -428,16 +439,35 @@ describe('io', () => {
         );
       });
     });
+
+    it('does not remove old todos if todos no longer contains violations if skipRemoval is true', async () => {
+      const fixture = getFixture('eslint-with-errors', tmp);
+      const todoDir = getTodoStorageDirPath(tmp);
+
+      const [added] = await writeTodos(tmp, fixture);
+
+      const initialFiles = await readFiles(todoDir);
+
+      expect(added).toEqual(18);
+      expect(initialFiles).toHaveLength(18);
+
+      const firstHalf = fixture.slice(0, 3);
+
+      const [, removed] = await writeTodos(tmp, firstHalf, { skipRemoval: true });
+
+      const subsequentFiles = await readFiles(todoDir);
+
+      expect(removed).toEqual(0);
+      expect(subsequentFiles).toHaveLength(18);
+    });
   });
 
   describe('writeTodos for single file', () => {
     it('generates todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(
-        tmp,
-        getFixture('single-file-todo', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added] = await writeTodos(tmp, getFixture('single-file-todo', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added).toEqual(3);
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
@@ -451,11 +481,9 @@ describe('io', () => {
 
     it('updates todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(
-        tmp,
-        getFixture('single-file-todo', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added] = await writeTodos(tmp, getFixture('single-file-todo', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added).toEqual(3);
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
@@ -469,7 +497,9 @@ describe('io', () => {
       const [added2, removed2] = await writeTodos(
         tmp,
         getFixture('single-file-todo-updated', tmp),
-        'app/controllers/settings.js'
+        {
+          filePath: 'app/controllers/settings.js',
+        }
       );
 
       expect(added2).toEqual(1);
@@ -485,11 +515,9 @@ describe('io', () => {
 
     it('deletes todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(
-        tmp,
-        getFixture('single-file-todo', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added] = await writeTodos(tmp, getFixture('single-file-todo', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added).toEqual(3);
       expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
@@ -500,11 +528,9 @@ describe('io', () => {
         ]
       `);
 
-      const [added2, removed2] = await writeTodos(
-        tmp,
-        getFixture('single-file-no-errors', tmp),
-        'app/controllers/settings.js'
-      );
+      const [added2, removed2] = await writeTodos(tmp, getFixture('single-file-no-errors', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
       expect(added2).toEqual(0);
       expect(removed2).toEqual(3);

--- a/src/io.ts
+++ b/src/io.ts
@@ -16,7 +16,14 @@ import {
   rmdir,
 } from 'fs-extra';
 import { buildTodoData } from './builders';
-import { TodoConfig, FilePath, LintResult, TodoData, TodoBatchCounts } from './types';
+import {
+  TodoConfig,
+  FilePath,
+  LintResult,
+  TodoData,
+  TodoBatchCounts,
+  WriteTodoOptions,
+} from './types';
 
 /**
  * Determines if the .lint-todo storage directory exists.
@@ -100,23 +107,6 @@ export function todoFileNameFor(todoData: TodoData): string {
   return createHash('sha256').update(hashParams).digest('hex').slice(0, 8);
 }
 
-export function writeTodosSync(baseDir: string, lintResults: LintResult[]): TodoBatchCounts;
-export function writeTodosSync(
-  baseDir: string,
-  lintResults: LintResult[],
-  filePath: string | undefined
-): TodoBatchCounts;
-export function writeTodosSync(
-  baseDir: string,
-  lintResults: LintResult[],
-  todoConfig: TodoConfig | undefined
-): TodoBatchCounts;
-export function writeTodosSync(
-  baseDir: string,
-  lintResults: LintResult[],
-  filePath: string | TodoConfig | undefined,
-  todoConfig?: TodoConfig
-): TodoBatchCounts;
 /**
  * Writes files for todo lint violations. One file is generated for each violation, using a generated
  * hash to identify each.
@@ -133,50 +123,27 @@ export function writeTodosSync(
 export function writeTodosSync(
   baseDir: string,
   lintResults: LintResult[],
-  filePath?: string | TodoConfig,
-  todoConfig?: TodoConfig
+  options: WriteTodoOptions = {}
 ): TodoBatchCounts {
-  if (typeof filePath === 'object') {
-    todoConfig = filePath;
-    filePath = '';
-  } else if (typeof filePath === 'undefined') {
-    filePath = '';
-  }
-
   const todoStorageDir: string = ensureTodoStorageDirSync(baseDir);
-  const existing: Map<FilePath, TodoData> = filePath
-    ? readTodosForFilePathSync(baseDir, filePath)
+  const existing: Map<FilePath, TodoData> = options.filePath
+    ? readTodosForFilePathSync(baseDir, options.filePath)
     : readTodosSync(baseDir);
-  const [add, remove] = getTodoBatchesSync(
-    buildTodoData(baseDir, lintResults, todoConfig),
+  // eslint-disable-next-line prefer-const
+  let [add, remove] = getTodoBatchesSync(
+    buildTodoData(baseDir, lintResults, options.todoConfig),
     existing
   );
+
+  if (options.skipRemoval) {
+    remove = new Map();
+  }
 
   applyTodoChangesSync(todoStorageDir, add, remove);
 
   return [add.size, remove.size];
 }
 
-export async function writeTodos(
-  baseDir: string,
-  lintResults: LintResult[]
-): Promise<TodoBatchCounts>;
-export async function writeTodos(
-  baseDir: string,
-  lintResults: LintResult[],
-  filePath: string | undefined
-): Promise<TodoBatchCounts>;
-export async function writeTodos(
-  baseDir: string,
-  lintResults: LintResult[],
-  todoConfig: TodoConfig | undefined
-): Promise<TodoBatchCounts>;
-export async function writeTodos(
-  baseDir: string,
-  lintResults: LintResult[],
-  filePath: string | TodoConfig | undefined,
-  todoConfig?: TodoConfig
-): Promise<TodoBatchCounts>;
 /**
  * Writes files for todo lint violations. One file is generated for each violation, using a generated
  * hash to identify each.
@@ -193,24 +160,21 @@ export async function writeTodos(
 export async function writeTodos(
   baseDir: string,
   lintResults: LintResult[],
-  filePath?: string | TodoConfig,
-  todoConfig?: TodoConfig
+  options: WriteTodoOptions = {}
 ): Promise<TodoBatchCounts> {
-  if (typeof filePath === 'object') {
-    todoConfig = filePath;
-    filePath = '';
-  } else if (typeof filePath === 'undefined') {
-    filePath = '';
-  }
-
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
-  const existing: Map<FilePath, TodoData> = filePath
-    ? await readTodosForFilePath(baseDir, filePath)
+  const existing: Map<FilePath, TodoData> = options.filePath
+    ? await readTodosForFilePath(baseDir, options.filePath)
     : await readTodos(baseDir);
-  const [add, remove] = await getTodoBatches(
-    buildTodoData(baseDir, lintResults, todoConfig),
+  // eslint-disable-next-line prefer-const
+  let [add, remove] = await getTodoBatches(
+    buildTodoData(baseDir, lintResults, options.todoConfig),
     existing
   );
+
+  if (options.skipRemoval) {
+    remove = new Map();
+  }
 
   await applyTodoChanges(todoStorageDir, add, remove);
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -16,14 +16,7 @@ import {
   rmdir,
 } from 'fs-extra';
 import { buildTodoData } from './builders';
-import {
-  TodoConfig,
-  FilePath,
-  LintResult,
-  TodoData,
-  TodoBatchCounts,
-  WriteTodoOptions,
-} from './types';
+import { FilePath, LintResult, TodoData, TodoBatchCounts, WriteTodoOptions } from './types';
 
 /**
  * Determines if the .lint-todo storage directory exists.

--- a/src/io.ts
+++ b/src/io.ts
@@ -116,8 +116,7 @@ export function todoFileNameFor(todoData: TodoData): string {
  *
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
  * @param lintResults - The raw linting data.
- * @param filePath - The relative file path of the file to update violations for.
- * @param todoConfig - An object containing the warn or error days, in integers.
+ * @param options - An object containing write options.
  * @returns - The counts of added and removed todos.
  */
 export function writeTodosSync(
@@ -153,8 +152,7 @@ export function writeTodosSync(
  *
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
  * @param lintResults - The raw linting data.
- * @param filePath - The relative file path of the file to update violations for.
- * @param todoConfig - An object containing the warn or error days, in integers.
+ * @param options - An object containing write options.
  * @returns - A promise that resolves to the counts of added and removed todos.
  */
 export async function writeTodos(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,3 +54,9 @@ export interface TodoConfig {
   warn?: number;
   error?: number;
 }
+
+export interface WriteTodoOptions {
+  filePath?: string;
+  todoConfig?: TodoConfig;
+  skipRemoval?: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,6 +55,13 @@ export interface TodoConfig {
   error?: number;
 }
 
+/**
+ * An optional configuration object passed to writeTodos.
+ *
+ * @param filePath - The relative file path of the file to update violations for.
+ * @param todoConfig - An object containing the warn or error days, in integers.
+ * @param skipRemoval - Allows for skipping removal of todo files.
+ */
 export interface WriteTodoOptions {
   filePath?: string;
   todoConfig?: TodoConfig;


### PR DESCRIPTION
In order to support use cases from consumers that require skipping the standard behavior of `writeTodos[Sync]`, which is to delete files that no longer have errors represented in the lint results, the signature of those functions have been changed.

```ts
function writeTodosSync(
  baseDir: string,
  lintResults: LintResult[],
  options: WriteTodoOptions = {}
): TodoBatchCounts;

async function writeTodos(
  baseDir: string,
  lintResults: LintResult[],
  options: WriteTodoOptions = {}
): Promise<TodoBatchCounts>
```

Both functions, the sync and async versions, now take an `options` parameter, which uses this interface:

```ts
interface WriteTodoOptions {
  filePath?: string;
  todoConfig?: TodoConfig;
  skipRemoval?: boolean;
}
```

This includes the new option, `skipRemoval`, which allows us to opt-out of deleting todo files when desired. This also has the added benefit of simplifying the optional argument juggling.