### PR TITLE
Returning defaults for todoConfig when none exist

### DIFF
--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -37,8 +37,7 @@ describe('todo-config', () => {
       });
     });
 
-    it.only('can returns empty lint todo config from package.json when empty config explicitly configured', () => {
-      debugger;
+    it('can returns empty lint todo config from package.json when empty config explicitly configured', () => {
       project.writeTodoConfig({});
 
       const config = getTodoConfig(project.baseDir);

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -19,13 +19,28 @@ describe('todo-config', () => {
   });
 
   describe('getTodoConfig', () => {
-    it('returns empty object when no package.json found', async () => {
+    it('returns default object when no package.json found', async () => {
       await unlink(join(project.baseDir, 'package.json'));
 
-      expect(getTodoConfig(project.baseDir)).toEqual({});
+      expect(getTodoConfig(project.baseDir)).toEqual({
+        warn: 30,
+        error: 60,
+      });
     });
 
-    it('returns empty object when no lint todo config found', () => {
+    it('returns default object when no lint todo config found', () => {
+      const config = getTodoConfig(project.baseDir);
+
+      expect(config).toEqual({
+        warn: 30,
+        error: 60,
+      });
+    });
+
+    it.only('can returns empty lint todo config from package.json when empty config explicitly configured', () => {
+      debugger;
+      project.writeTodoConfig({});
+
       const config = getTodoConfig(project.baseDir);
 
       expect(config).toEqual({});

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -43,12 +43,7 @@ export function getTodoConfig(
 
   // we set a default config if the mergedConfig is an empty object, meaning either or both warn and error aren't
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig)
-  if (
-    Object.keys(mergedConfig).length === 0 &&
-    (typeof daysToDecayPackageConfig === 'undefined' ||
-      (typeof daysToDecayPackageConfig === 'object' &&
-        Object.keys(daysToDecayPackageConfig).length !== 0))
-  ) {
+  if (Object.keys(mergedConfig).length === 0 && typeof daysToDecayPackageConfig === 'undefined') {
     mergedConfig = {
       warn: 30,
       error: 60,

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -45,8 +45,9 @@ export function getTodoConfig(
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig)
   if (
     Object.keys(mergedConfig).length === 0 &&
-    typeof daysToDecayPackageConfig !== 'undefined' &&
-    Object.keys(daysToDecayPackageConfig).length !== 0
+    (typeof daysToDecayPackageConfig === 'undefined' ||
+      (typeof daysToDecayPackageConfig === 'object' &&
+        Object.keys(daysToDecayPackageConfig).length !== 0))
   ) {
     mergedConfig = {
       warn: 30,


### PR DESCRIPTION
The `ensureTodoConfig` API existed so that we could ensure todos had a default daysToDecay set. This ensures that todos are not created and forgotten.

When implementing this, @rwjblue and I realized we could implement a 'lighter touch', one that wouldn't require us to mutate a project's package.json file, which can feel very invasive from a linting tool. Instead, we're not falling back to a default todo config when one is not encountered. The order of precedence is the following, with topmost being used before those below:

- Options in the command line
- Environment variables
- package.json configuration
- defaults 

	```json
	{
	  "warn": 30,
	  "error": 60
	}
	```

If a consumer wants to 'opt out' of using a todo config entirely, they can set it to an empty object in the package.json.