### PR TITLE
Adding test to ensure engine scoped removal works using shouldRemove

### DIFF
--- a/__tests__/__fixtures__/eslint-single-error2.json
+++ b/__tests__/__fixtures__/eslint-single-error2.json
@@ -1,0 +1,20 @@
+{
+  "results": [
+    {
+      "filePath": "{{path}}/app/initializers/tracer.js",
+      "messages": [
+        {
+          "ruleId": "no-redeclare",
+          "severity": 2,
+          "message": "'window' is already defined as a built-in global variable.",
+          "line": 1,
+          "column": 11,
+          "nodeType": "Block",
+          "messageId": "redeclaredAsBuiltin",
+          "endLine": 1,
+          "endColumn": 17
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdir, statSync } from 'fs-extra';
+import { existsSync, readdir, statSync, readJson } from 'fs-extra';
 import { posix } from 'path';
 import {
   buildTodoData,
@@ -438,6 +438,52 @@ describe('io', () => {
           true
         );
       });
+    });
+
+    it('does not remove todos owned by different engine', async () => {
+      const todoDir = getTodoStorageDirPath(tmp);
+
+      await writeTodos(tmp, getFixture('ember-template-lint-single-error', tmp));
+
+      const fixture = getFixture('eslint-single-error', tmp);
+
+      const [added] = await writeTodos(tmp, fixture, {
+        shouldRemove: (todoDatum) => todoDatum.engine === 'eslint',
+      });
+
+      const initialFiles = await readFiles(todoDir);
+
+      expect(added).toEqual(1);
+      expect(initialFiles).toHaveLength(2);
+
+      const [, removed] = await writeTodos(tmp, getFixture('eslint-single-error2', tmp), {
+        shouldRemove: (todoDatum) => todoDatum.engine === 'eslint',
+      });
+
+      const subsequentFiles = await readFiles(todoDir);
+
+      expect(removed).toEqual(1);
+      expect(subsequentFiles).toHaveLength(2);
+      expect(await readJson(posix.join(todoDir, subsequentFiles[0]))).toMatchInlineSnapshot(`
+        Object {
+          "column": 11,
+          "createdDate": 1612425600000,
+          "engine": "eslint",
+          "filePath": "app/initializers/tracer.js",
+          "line": 1,
+          "ruleId": "no-redeclare",
+        }
+      `);
+      expect(await readJson(posix.join(todoDir, subsequentFiles[1]))).toMatchInlineSnapshot(`
+        Object {
+          "column": 4,
+          "createdDate": 1612425600000,
+          "engine": "ember-template-lint",
+          "filePath": "app/templates/components/add-ssh-key.hbs",
+          "line": 3,
+          "ruleId": "require-input-label",
+        }
+      `);
     });
 
     it('does not remove old todos if todos no longer contains violations if shouldRemove returns false', async () => {

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -464,26 +464,25 @@ describe('io', () => {
 
       expect(removed).toEqual(1);
       expect(subsequentFiles).toHaveLength(2);
-      expect(await readJson(posix.join(todoDir, subsequentFiles[0]))).toMatchInlineSnapshot(`
-        Object {
-          "column": 11,
-          "createdDate": 1612425600000,
-          "engine": "eslint",
-          "filePath": "app/initializers/tracer.js",
-          "line": 1,
-          "ruleId": "no-redeclare",
-        }
-      `);
-      expect(await readJson(posix.join(todoDir, subsequentFiles[1]))).toMatchInlineSnapshot(`
-        Object {
-          "column": 4,
-          "createdDate": 1612425600000,
-          "engine": "ember-template-lint",
-          "filePath": "app/templates/components/add-ssh-key.hbs",
-          "line": 3,
-          "ruleId": "require-input-label",
-        }
-      `);
+      expect(await readJson(posix.join(todoDir, subsequentFiles[0]))).toEqual(
+        expect.objectContaining({
+          column: 11,
+          engine: 'eslint',
+          filePath: 'app/initializers/tracer.js',
+          line: 1,
+          ruleId: 'no-redeclare',
+        })
+      );
+      expect(await readJson(posix.join(todoDir, subsequentFiles[1]))).toEqual(
+        expect.objectContaining({
+          column: 4,
+          createdDate: 1612425600000,
+          engine: 'ember-template-lint',
+          filePath: 'app/templates/components/add-ssh-key.hbs',
+          line: 3,
+          ruleId: 'require-input-label',
+        })
+      );
     });
 
     it('does not remove old todos if todos no longer contains violations if shouldRemove returns false', async () => {

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -476,7 +476,6 @@ describe('io', () => {
       expect(await readJson(posix.join(todoDir, subsequentFiles[1]))).toEqual(
         expect.objectContaining({
           column: 4,
-          createdDate: 1612425600000,
           engine: 'ember-template-lint',
           filePath: 'app/templates/components/add-ssh-key.hbs',
           line: 3,


### PR DESCRIPTION
Ensures that we can scope removals by engine using the `shouldRemove` API.