### PR TITLE
Adding expired batch to getTodoBatches

### DIFF
--- a/__tests__/__fixtures__/existing-batches.json
+++ b/__tests__/__fixtures__/existing-batches.json
@@ -23,6 +23,17 @@
         "messageId": "redeclaredAsBuiltin",
         "endLine": 1,
         "endColumn": 33
+      },
+      {
+        "ruleId": "no-redeclare",
+        "severity": 2,
+        "message": "'XMLHttpRequest' is already defined as a built-in global variable.",
+        "line": 1,
+        "column": 119,
+        "nodeType": "Block",
+        "messageId": "redeclaredAsBuiltin",
+        "endLine": 1,
+        "endColumn": 133
       }
     ],
     "errorCount": 2,

--- a/__tests__/__fixtures__/new-batches.json
+++ b/__tests__/__fixtures__/new-batches.json
@@ -67,6 +67,17 @@
         "messageId": "redeclaredAsBuiltin",
         "endLine": 1,
         "endColumn": 33
+      },
+      {
+        "ruleId": "no-redeclare",
+        "severity": 2,
+        "message": "'XMLHttpRequest' is already defined as a built-in global variable.",
+        "line": 1,
+        "column": 119,
+        "nodeType": "Block",
+        "messageId": "redeclaredAsBuiltin",
+        "endLine": 1,
+        "endColumn": 133
       }
     ],
     "errorCount": 2,

--- a/__tests__/date-utils-test.ts
+++ b/__tests__/date-utils-test.ts
@@ -1,0 +1,19 @@
+import { subDays, addDays } from 'date-fns';
+import { isExpired, getDatePart } from '../src/date-utils';
+
+describe('isExpired', () => {
+  let today: number;
+
+  beforeEach(() => {
+    today = getDatePart().getTime();
+  });
+
+  it('returns false when a date is not expired', () => {
+    expect(isExpired(getDatePart().getTime(), today)).toEqual(false);
+    expect(isExpired(addDays(getDatePart(), 1).getTime(), today)).toEqual(false);
+  });
+
+  it('returns true when a date is expired', () => {
+    expect(isExpired(subDays(getDatePart(), 1).getTime(), today)).toEqual(true);
+  });
+});

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -730,10 +730,44 @@ describe('io', () => {
       `);
     });
 
-    it('creates all batches', async () => {
-      const [add, remove, stable] = await getTodoBatches(
+    it('creates items to expire', async () => {
+      const expiredBatches: Map<string, TodoData> = buildTodoData(
+        tmp,
+        getFixture('new-batches', tmp)
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const expiredTodo: TodoData = expiredBatches.get(
+        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
+      )!;
+
+      expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
+
+      // eslint-disable-next-line unicorn/no-unreadable-array-destructuring
+      const [, , , expired] = await getTodoBatches(
         buildTodoData(tmp, getFixture('new-batches', tmp)),
-        buildTodoData(tmp, getFixture('existing-batches', tmp)),
+        expiredBatches,
+        { shouldRemove: () => true }
+      );
+
+      expect([...expired.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+        ]
+      `);
+    });
+
+    it('creates all batches', async () => {
+      const existingBatches = buildTodoData(tmp, getFixture('existing-batches', tmp));
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const expiredTodo: TodoData = existingBatches.get(
+        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
+      )!;
+
+      expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
+
+      const [add, remove, stable, expired] = await getTodoBatches(
+        buildTodoData(tmp, getFixture('new-batches', tmp)),
+        existingBatches,
         { shouldRemove: () => true }
       );
 
@@ -754,6 +788,10 @@ describe('io', () => {
         Array [
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+        ]
+      `);
+      expect([...expired.keys()]).toMatchInlineSnapshot(`
+        Array [
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
         ]
       `);

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdir, statSync, readJson } from 'fs-extra';
 import { posix } from 'path';
+import { subDays } from 'date-fns';
 import {
   buildTodoData,
   ensureTodoStorageDir,
@@ -598,6 +599,7 @@ describe('io', () => {
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
         ]
       `);
     });
@@ -616,14 +618,49 @@ describe('io', () => {
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+        ]
+      `);
+    });
+
+    it('creates items to expire', async () => {
+      const expiredBatches: Map<string, TodoData> = buildTodoData(
+        tmp,
+        getFixture('new-batches', tmp)
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const expiredTodo: TodoData = expiredBatches.get(
+        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
+      )!;
+
+      expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
+
+      // eslint-disable-next-line unicorn/no-unreadable-array-destructuring
+      const [, , , expired] = getTodoBatchesSync(
+        buildTodoData(tmp, getFixture('new-batches', tmp)),
+        expiredBatches,
+        { shouldRemove: () => true }
+      );
+
+      expect([...expired.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
         ]
       `);
     });
 
     it('creates all batches', async () => {
-      const [add, remove, stable] = getTodoBatchesSync(
+      const existingBatches = buildTodoData(tmp, getFixture('existing-batches', tmp));
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const expiredTodo: TodoData = existingBatches.get(
+        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
+      )!;
+
+      expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
+
+      const [add, remove, stable, expired] = getTodoBatchesSync(
         buildTodoData(tmp, getFixture('new-batches', tmp)),
-        buildTodoData(tmp, getFixture('existing-batches', tmp)),
+        existingBatches,
         { shouldRemove: () => true }
       );
 
@@ -646,6 +683,11 @@ describe('io', () => {
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
         ]
       `);
+      expect([...expired.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+        ]
+      `);
     });
   });
 
@@ -664,6 +706,7 @@ describe('io', () => {
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
         ]
       `);
     });
@@ -682,6 +725,7 @@ describe('io', () => {
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
         ]
       `);
     });
@@ -710,6 +754,7 @@ describe('io', () => {
         Array [
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
           "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
         ]
       `);
     });

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -2,7 +2,7 @@ import { isAbsolute, relative } from 'path';
 import slash = require('slash');
 import { todoFilePathFor } from './io';
 import { TodoConfig, FilePath, LintMessage, LintResult, TodoData } from './types';
-import { getDatePart } from './get-severity';
+import { getDatePart } from './date-utils';
 
 /**
  * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Evaluates whether a date is expired (earlier than today)
+ *
+ * @param date - The date to evaluate
+ * @param today - A number representing a date (UNIX Epoch - milliseconds)
+ * @returns true if the date is earlier than today, otherwise false
+ */
+export function isExpired(
+  date: number | undefined,
+  today: number = getDatePart().getTime()
+): boolean {
+  return date !== undefined && today > date;
+}
+
+/**
+ * Converts a date to include year, month, and day values only (time is zeroed out).
+ *
+ * @param date - The date to convert
+ * @returns Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
+ */
+export function getDatePart(date: Date = new Date()): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
+}

--- a/src/get-severity.ts
+++ b/src/get-severity.ts
@@ -1,3 +1,4 @@
+import { isExpired, getDatePart } from './date-utils';
 import { Severity, TodoData } from './types';
 
 /**
@@ -8,21 +9,11 @@ import { Severity, TodoData } from './types';
  * @returns Severity - the lint severity based on the evaluation of the decay dates.
  */
 export function getSeverity(todo: TodoData, today: number = getDatePart().getTime()): Severity {
-  if (todo.errorDate && today > todo.errorDate) {
+  if (isExpired(todo.errorDate, today)) {
     return Severity.error;
-  } else if (todo.warnDate && today > todo.warnDate) {
+  } else if (isExpired(todo.warnDate)) {
     return Severity.warn;
   }
 
   return Severity.todo;
-}
-
-/**
- * Converts a date to include year, month, and day values only (time is zeroed out).
- *
- * @param date - The date to convert
- * @returns Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
- */
-export function getDatePart(date: Date = new Date()): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
   writeTodosSync,
 } from './io';
 export { getTodoConfig, writeTodoConfig, ensureTodoConfig } from './todo-config';
-export { getSeverity, getDatePart } from './get-severity';
+export { getSeverity } from './get-severity';
+export { getDatePart, isExpired } from './date-utils';
 
 export * from './types';

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { createHash } from 'crypto';
 import { posix } from 'path';
 import {
@@ -306,18 +307,22 @@ export function getTodoBatchesSync(
     if (!existing.has(fileHash)) {
       add.set(fileHash, todoDatum);
     } else {
-      stable.set(fileHash, todoDatum);
+      const existingTodo = existing.get(fileHash);
+      if (existingTodo && !isExpired(existingTodo.errorDate)) {
+        stable.set(fileHash, todoDatum);
+      }
     }
   }
 
   for (const [fileHash, todoDatum] of existing) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (!lintResults.has(fileHash) && options.shouldRemove!(todoDatum)) {
-      if (isExpired(todoDatum.errorDate)) {
-        expired.set(fileHash, todoDatum);
-      } else {
-        remove.set(fileHash, todoDatum);
-      }
+    if (
+      lintResults.has(fileHash) &&
+      isExpired(todoDatum.errorDate) &&
+      options.shouldRemove!(todoDatum)
+    ) {
+      expired.set(fileHash, todoDatum);
+    } else if (!lintResults.has(fileHash) && options.shouldRemove!(todoDatum)) {
+      remove.set(fileHash, todoDatum);
     } else {
       stable.set(fileHash, todoDatum);
     }

--- a/src/io.ts
+++ b/src/io.ts
@@ -352,18 +352,22 @@ export async function getTodoBatches(
     if (!existing.has(fileHash)) {
       add.set(fileHash, todoDatum);
     } else {
-      stable.set(fileHash, todoDatum);
+      const existingTodo = existing.get(fileHash);
+      if (existingTodo && !isExpired(existingTodo.errorDate)) {
+        stable.set(fileHash, todoDatum);
+      }
     }
   }
 
   for (const [fileHash, todoDatum] of existing) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (!lintResults.has(fileHash) && options.shouldRemove!(todoDatum)) {
-      if (isExpired(todoDatum.errorDate)) {
-        expired.set(fileHash, todoDatum);
-      } else {
-        remove.set(fileHash, todoDatum);
-      }
+    if (
+      lintResults.has(fileHash) &&
+      isExpired(todoDatum.errorDate) &&
+      options.shouldRemove!(todoDatum)
+    ) {
+      expired.set(fileHash, todoDatum);
+    } else if (!lintResults.has(fileHash) && options.shouldRemove!(todoDatum)) {
+      remove.set(fileHash, todoDatum);
     } else {
       stable.set(fileHash, todoDatum);
     }


### PR DESCRIPTION
We'd like to be able to support `expired` batches in addition to `add`, `remove`, and `stable`. This allows us to disambiguate which todos are considered expired, and thus effectively no longer useful to track. It also allows consuming apps to be able to delete those `expired` todos easily, without having to determine whether they're expired or not themselves.

We prevented this being a breaking change by adding the `expired` to the end of the tuple, thus widening the API without a backwards incompatible change.