### PR TITLE
Adds support for decay days to be set per rule

### DIFF
--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -1,6 +1,6 @@
 import type { DirJSON } from 'fixturify';
 import Project from 'fixturify-project';
-import { TodoConfig } from '../../src';
+import { DaysToDecay } from '../../src';
 
 export class FakeProject extends Project {
   constructor(name = 'fake-project', ...args: any[]) {
@@ -18,7 +18,7 @@ export class FakeProject extends Project {
     this.writeSync();
   }
 
-  writeTodoConfig(todoConfig: TodoConfig["daysToDecay"]): void {
+  writeTodoConfig(todoConfig: DaysToDecay): void {
     this.pkg = Object.assign({}, this.pkg, {
       lintTodo: {
         daysToDecay: todoConfig,

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -18,7 +18,7 @@ export class FakeProject extends Project {
     this.writeSync();
   }
 
-  writeTodoConfig(todoConfig: TodoConfig): void {
+  writeTodoConfig(todoConfig: TodoConfig["daysToDecay"]): void {
     this.pkg = Object.assign({}, this.pkg, {
       lintTodo: {
         daysToDecay: todoConfig,

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -2,7 +2,6 @@ import { unlink, readFileSync, writeFileSync } from 'fs-extra';
 import { join } from 'path';
 import { getTodoConfig, writeTodoConfig, ensureTodoStorageDirSync } from '../src';
 import { FakeProject } from './__utils__/fake-project';
-import { ensureTodoConfig } from '../src/todo-config';
 
 describe('todo-config', () => {
   let project: FakeProject;
@@ -172,76 +171,6 @@ describe('todo-config', () => {
       expect(() => getTodoConfig(project.baseDir, { warn: 10, error: 5 })).toThrow(
         'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
       );
-    });
-  });
-
-  describe('ensureTodoConfig', () => {
-    it('does not change package.json if lintTodo directory present', () => {
-      ensureTodoStorageDirSync(project.baseDir);
-
-      const originalPkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      ensureTodoConfig(project.baseDir);
-
-      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      expect(pkg).toEqual(originalPkg);
-    });
-
-    it('does not change package.json if todo config already present', () => {
-      ensureTodoStorageDirSync(project.baseDir);
-
-      writeTodoConfig(project.baseDir, {
-        warn: 10,
-        error: 20,
-      });
-
-      const originalPkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      ensureTodoConfig(project.baseDir);
-
-      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      expect(pkg).toEqual(originalPkg);
-    });
-
-    it('does not change package.json if todo config is empty object', () => {
-      ensureTodoStorageDirSync(project.baseDir);
-
-      writeTodoConfig(project.baseDir, {});
-
-      const originalPkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      ensureTodoConfig(project.baseDir);
-
-      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      expect(pkg).toEqual(originalPkg);
-    });
-
-    it('does change package.json if lintTodo directory not present', () => {
-      ensureTodoConfig(project.baseDir);
-
-      const pkg = readFileSync(join(project.baseDir, 'package.json'), { encoding: 'utf8' });
-
-      expect(pkg).toMatchInlineSnapshot(`
-        "{
-          \\"name\\": \\"fake-project\\",
-          \\"version\\": \\"0.0.0\\",
-          \\"keywords\\": [],
-          \\"license\\": \\"MIT\\",
-          \\"description\\": \\"Fake project\\",
-          \\"repository\\": \\"http://fakerepo.com\\",
-          \\"dependencies\\": {},
-          \\"devDependencies\\": {},
-          \\"lintTodo\\": {
-            \\"daysToDecay\\": {
-              \\"warn\\": 30,
-              \\"error\\": 60
-            }
-          }
-        }"
-      `);
     });
   });
 

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -40,12 +40,14 @@ describe('todo-config', () => {
       });
     });
 
-    it('can returns empty lint todo config from package.json when empty config explicitly configured', () => {
+    it('can return empty lint todo config from package.json when empty config explicitly configured', () => {
       project.writeTodoConfig({});
 
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({});
+      expect(config).toEqual({
+        "daysToDecay": {}
+      });
     });
 
     it('can get lint todo config from package.json', () => {
@@ -57,8 +59,10 @@ describe('todo-config', () => {
       const config = getTodoConfig(project.baseDir);
 
       expect(config).toEqual({
-        warn: 5,
-        error: 10,
+        "daysToDecay": {
+          warn: 5,
+          error: 10,
+        }
       });
     });
 

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -1,6 +1,6 @@
 import { unlink, readFileSync, writeFileSync } from 'fs-extra';
 import { join } from 'path';
-import { getTodoConfig, writeTodoConfig, ensureTodoStorageDirSync } from '../src';
+import { getTodoConfig, writeTodoConfig } from '../src';
 import { FakeProject } from './__utils__/fake-project';
 
 describe('todo-config', () => {
@@ -22,8 +22,10 @@ describe('todo-config', () => {
       await unlink(join(project.baseDir, 'package.json'));
 
       expect(getTodoConfig(project.baseDir)).toEqual({
-        warn: 30,
-        error: 60,
+        "daysToDecay": {
+          warn: 30,
+          error: 60,
+        }
       });
     });
 
@@ -31,8 +33,10 @@ describe('todo-config', () => {
       const config = getTodoConfig(project.baseDir);
 
       expect(config).toEqual({
-        warn: 30,
-        error: 60,
+        "daysToDecay": {
+          warn: 30,
+          error: 60,
+        }
       });
     });
 
@@ -81,8 +85,8 @@ describe('todo-config', () => {
 
     it('can override lint todo config from package.json with env vars', () => {
       project.writeTodoConfig({
-        warn: 1,
-        error: 2,
+          warn: 1,
+          error: 2,
       });
 
       setupEnvVar('TODO_DAYS_TO_WARN', '5');
@@ -147,8 +151,8 @@ describe('todo-config', () => {
 
     it('can override defaults with single null value', () => {
       project.writeTodoConfig({
-        warn: 1,
-        error: 2,
+          warn: 1,
+          error: 2,
       });
 
       const config = getTodoConfig(project.baseDir, {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
 import { todoFilePathFor } from './io';
-import { TodoConfig, FilePath, LintMessage, LintResult, TodoData } from './types';
+import { DaysToDecay, FilePath, LintMessage, LintResult, TodoData } from './types';
 import { getDatePart } from './date-utils';
 
 /**
@@ -15,7 +15,7 @@ import { getDatePart } from './date-utils';
 export function buildTodoData(
   baseDir: string,
   lintResults: LintResult[],
-  todoConfig?: TodoConfig
+  todoConfig?: DaysToDecay
 ): Map<FilePath, TodoData> {
   const results = lintResults.filter((result) => result.messages.length > 0);
 
@@ -48,7 +48,7 @@ export function _buildTodoDatum(
   baseDir: string,
   lintResult: LintResult,
   lintMessage: LintMessage,
-  todoConfig?: TodoConfig
+  todoConfig?: DaysToDecay
 ): TodoData {
   // Note: If https://github.com/nodejs/node/issues/13683 is fixed, remove slash() and use posix.relative
   // provided that the fix is landed on the supported node versions of this lib

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {
   readTodosForFilePathSync,
   writeTodosSync,
 } from './io';
-export { getTodoConfig, writeTodoConfig, ensureTodoConfig } from './todo-config';
+export { getTodoConfig, writeTodoConfig } from './todo-config';
 export { getSeverity } from './get-severity';
 export { getDatePart, isExpired } from './date-utils';
 

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -156,8 +156,8 @@ function getFromTodoConfigFile(basePath: string): TodoConfig["daysToDecay"] | un
 }
 
 // what is the syntax here?
-function getFromEnvVars(): TodoConfig["daysToDecay"] {
-  const config: TodoConfig["daysToDecay"] = {};
+function getFromEnvVars(): DaysToDecay {
+  const config: DaysToDecay = {};
 
   const warn = getEnvVar('TODO_DAYS_TO_WARN');
   const error = getEnvVar('TODO_DAYS_TO_ERROR');

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -39,7 +39,7 @@ export function getTodoConfig(
 ): TodoConfig | undefined {
   const daysToDecayPackageConfig = getFromPackageJson(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
-  const daysToDecayByRuleConfig = getFromTodoRuleConfigFile(baseDir);
+  const daysToDecayByRuleConfig = getFromTodoConfigFile(baseDir);
   let mergedConfig = Object.assign({}, daysToDecayPackageConfig, daysToDecayByRuleConfig, daysToDecayEnvVars, todoConfig);
 
   // we set a default config if the mergedConfig is an empty object, meaning either or both warn and error aren't
@@ -96,12 +96,12 @@ export function ensureTodoConfig(baseDir: string): void {
  */
 export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig): boolean {
   const packageJsonPath = join(baseDir, 'package.json');
-  const todoRuleConfigFile = join(baseDir, '.lint-todorc.js');
+  const todoConfigFile = join(baseDir, '.lint-todorc.js');
   const contents = readFileSync(packageJsonPath, { encoding: 'utf8' });
-  const ruleConfigContents = readFileSync(todoRuleConfigFile, { encoding: 'utf8' });
+  const todoConfigContents = readFileSync(todoConfigFile, { encoding: 'utf8' });
   const trailingWhitespace = DETECT_TRAILING_WHITESPACE.exec(contents);
   const pkg = JSON.parse(contents);
-  const ruleConfig = JSON.parse(ruleConfigContents);
+  const ruleConfig = JSON.parse(todoConfigContents);
 
   // if there is no lintTodo config in the package.json OR .lint-todorc.js file
   if (pkg.lintTodo || ruleConfig.lintTodo) {
@@ -135,7 +135,7 @@ function getFromPackageJson(basePath: string): TodoConfig | undefined {
   return pkg?.lintTodo?.daysToDecay;
 }
 
-function getFromTodoRuleConfigFile(basePath: string): TodoConfig | undefined {
+function getFromTodoConfigFile(basePath: string): TodoConfig | undefined {
   let ruleConfig;
 
   try {

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -51,11 +51,11 @@ const DETECT_TRAILING_WHITESPACE = /\s+$/;
  * @returns - The todo config object.
  */
 
-// are we changing this to be get DaysToDecay since we're just trying to set default daysToDecay and don't care about per-rule settings
+// rename this later, it doesn't get the whole todoConfig just the daysToDecay
 export function getTodoConfig(
   baseDir: string,
   todoConfig: TodoConfig["daysToDecay"] = {}
-): TodoConfig | undefined {
+): TodoConfig["daysToDecay"] | undefined {
   const daysToDecayPackageConfig = getFromPackageJson(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
   const daysToDecayLintTodoConfig = getFromTodoConfigFile(baseDir);
@@ -94,14 +94,14 @@ export function getTodoConfig(
  * @param baseDir - The base directory that contains the project's package.json or .lint-todorc.js.
  * @param todoConfig - The todo configuration to write to the package.json or .lint-todorc.js.
  */
-export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig): boolean {
+export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig["daysToDecay"]): boolean {
   const packageJsonPath = join(baseDir, 'package.json');
   const contents = readFileSync(packageJsonPath, { encoding: 'utf8' });
   const pkg = JSON.parse(contents);
 
   const todoConfigFile = join(baseDir, '.lint-todorc.js');
-  const todoConfigContents = readFileSync(todoConfigFile, { encoding: 'utf8' });
-  const ruleConfig = JSON.parse(todoConfigContents);
+  // const todoConfigContents = readFileSync(todoConfigFile, { encoding: 'utf8' });
+  // const ruleConfig = JSON.parse(todoConfigContents);
 
   const trailingWhitespace = DETECT_TRAILING_WHITESPACE.exec(contents);
 
@@ -125,8 +125,11 @@ export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig): boolea
   return true;
 }
 
+// for the next two functions, could we combine them into one function with conditionals?
+// we'd need to refactor the `getTodoConfig` function that use these.
+
 // if package.json has lintTodo config, return those values
-function getFromPackageJson(basePath: string): TodoConfig | undefined {
+function getFromPackageJson(basePath: string): TodoConfig["daysToDecay"] | undefined {
   let pkg;
 
   try {
@@ -134,11 +137,11 @@ function getFromPackageJson(basePath: string): TodoConfig | undefined {
     pkg = require(join(basePath, 'package.json'));
   } catch {}
 
-  return pkg?.lintTodo?.daysToDecay;
+  return pkg?.lintTodo;
 }
 
 // if .lint-todorc.js exists, return the values for daysToDecay
-function getFromTodoConfigFile(basePath: string): DaysToDecay | undefined {
+function getFromTodoConfigFile(basePath: string): TodoConfig["daysToDecay"] | undefined {
   let todoDaysToDecayDefaultConfig;
 
   try {
@@ -146,14 +149,13 @@ function getFromTodoConfigFile(basePath: string): DaysToDecay | undefined {
     todoDaysToDecayDefaultConfig = require(join(basePath, '.lint-todorc.js'));
   } catch {}
 
-  // this won't be `lintTodo` because that won't be in the .lint-todorc.js file
-  // but how do we abstract "whatever the name of the engine is" into syntax that will be accepted?
-  return todoDaysToDecayDefaultConfig?.lintTodo?.daysToDecay;
+  // abstract "whatever the name of the engine is" into syntax that will be accepted
+  return todoDaysToDecayDefaultConfig?.["ember-template-lint"].daysToDecay;
 }
 
 // what is the syntax here?
-function getFromEnvVars(): TodoConfig {
-  const config: TodoConfig = {};
+function getFromEnvVars(): TodoConfig["daysToDecay"] {
+  const config: TodoConfig["daysToDecay"] = {};
 
   const warn = getEnvVar('TODO_DAYS_TO_WARN');
   const error = getEnvVar('TODO_DAYS_TO_ERROR');

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -79,7 +79,7 @@ export function ensureTodoConfig(baseDir: string): void {
 
     if (!ruleConfigFile) {
       if (!pkg.lintTodo) {
-        writeTodoConfig(baseDir, {
+        writeTodoConfig(pkg, {
           warn: 30,
           error: 60,
         });
@@ -104,14 +104,22 @@ export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig): boolea
   const ruleConfig = JSON.parse(todoConfigContents);
 
   // if there is no lintTodo config in the package.json OR .lint-todorc.js file
-  if (pkg.lintTodo || ruleConfig.lintTodo) {
+  if (pkg.lintTodo || todoConfigFile) {
     return false;
   }
 
-  // write the default daysToDecay to the package.json
-  pkg.lintTodo = {
-    daysToDecay: todoConfig,
-  };
+  // if there's a .lint-todorc.js file but no lintTodo config
+  if (todoConfigFile && !ruleConfig.lintTodo) {
+    // write the default daysToDecay to the .lint-todorc.js file
+    ruleConfig.lintTodo = {
+      daysToDecay: todoConfig,
+    };
+  } else {
+    // write the default daysToDecay to the package.json
+    pkg.lintTodo = {
+      daysToDecay: todoConfig,
+    };
+  }
 
   let updatedContents = JSON.stringify(pkg, undefined, 2);
 

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -75,15 +75,17 @@ export function getTodoConfig(
 export function ensureTodoConfig(baseDir: string): void {
   if (!todoStorageDirExists(baseDir)) {
     const pkg = readJsonSync(join(baseDir, 'package.json'));
-    const ruleConfigFile = readJsonSync(join(baseDir, '.lint-todorc.js'));
+    const ruleConfigFile = require(join(baseDir, '.lint-todorc.js'));
 
-    if (!ruleConfigFile) {
-      if (!pkg.lintTodo) {
-        writeTodoConfig(pkg, {
-          warn: 30,
-          error: 60,
-        });
-      }
+    if (ruleConfigFile) {
+      return;
+    }
+
+    if (!pkg.lintTodo) {
+      writeTodoConfig(pkg, {
+        warn: 30,
+        error: 60,
+      });
     }
   }
 }

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -39,8 +39,8 @@ export function getTodoConfig(
 ): TodoConfig | undefined {
   const daysToDecayPackageConfig = getFromPackageJson(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
-  const daysToDecayByRuleConfig = getFromTodoConfigFile(baseDir);
-  let mergedConfig = Object.assign({}, daysToDecayPackageConfig, daysToDecayByRuleConfig, daysToDecayEnvVars, todoConfig);
+  const daysToDecayLintTodoConfig = getFromTodoConfigFile(baseDir);
+  let mergedConfig = Object.assign({}, daysToDecayPackageConfig, daysToDecayLintTodoConfig, daysToDecayEnvVars, todoConfig);
 
   // we set a default config if the mergedConfig is an empty object, meaning either or both warn and error aren't
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig)

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -54,8 +54,8 @@ const DETECT_TRAILING_WHITESPACE = /\s+$/;
 // rename this later, it doesn't get the whole todoConfig just the daysToDecay
 export function getTodoConfig(
   baseDir: string,
-  todoConfig: TodoConfig["daysToDecay"] = {}
-): TodoConfig["daysToDecay"] | undefined {
+  todoConfig: DaysToDecay = {}
+): DaysToDecay | undefined {
   const daysToDecayPackageConfig = getFromPackageJson(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
   const daysToDecayLintTodoConfig = getFromTodoConfigFile(baseDir);
@@ -70,8 +70,10 @@ export function getTodoConfig(
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig(now daysToDecay))
   if (Object.keys(mergedConfig).length === 0 && typeof daysToDecayPackageConfig === 'undefined' && typeof daysToDecayLintTodoConfig === 'undefined') {
     mergedConfig = {
-      warn: 30,
-      error: 60,
+      "daysToDecay": {
+        warn: 30,
+        error: 60,
+      }
     };
   }
 
@@ -94,7 +96,7 @@ export function getTodoConfig(
  * @param baseDir - The base directory that contains the project's package.json or .lint-todorc.js.
  * @param todoConfig - The todo configuration to write to the package.json or .lint-todorc.js.
  */
-export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig["daysToDecay"]): boolean {
+export function writeTodoConfig(baseDir: string, todoConfig: DaysToDecay): boolean {
   const packageJsonPath = join(baseDir, 'package.json');
   const contents = readFileSync(packageJsonPath, { encoding: 'utf8' });
   const pkg = JSON.parse(contents);
@@ -129,7 +131,7 @@ export function writeTodoConfig(baseDir: string, todoConfig: TodoConfig["daysToD
 // we'd need to refactor the `getTodoConfig` function that use these.
 
 // if package.json has lintTodo config, return those values
-function getFromPackageJson(basePath: string): TodoConfig["daysToDecay"] | undefined {
+function getFromPackageJson(basePath: string): DaysToDecay | undefined {
   let pkg;
 
   try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,8 +48,6 @@ export type LintTodoPackageJson = PackageJson & {
   lintTodo?: TodoConfig;
 };
 
-// should I do something like LintTodoPackageJson for the .lint-todorc.js file? or should I add it above?
-
 export type TodoBatchCounts = [number, number];
 
 export interface DaysToDecay {
@@ -62,13 +60,6 @@ export interface TodoConfig {
   decayDaysByRule: {
     [ruleId: string]: DaysToDecay;
   }
-}
-
-// do I need this here?
-export interface TodoConfigByRule {
-  ruleId?: string;
-  warn?: number;
-  error?: number;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,16 +45,23 @@ export interface TodoData {
 }
 
 export type LintTodoPackageJson = PackageJson & {
-  lintTodo?: { daysToDecay: TodoConfig };
+  lintTodo?: TodoConfig;
 };
 
-// should I do something like LintTodoPackageJson for the .lint-todorc.js file?
+// should I do something like LintTodoPackageJson for the .lint-todorc.js file? or should I add it above?
 
 export type TodoBatchCounts = [number, number];
 
-export interface TodoConfig {
+export interface DaysToDecay {
   warn?: number;
   error?: number;
+}
+
+export interface TodoConfig {
+  daysToDecay: DaysToDecay;
+  decayDaysByRule: {
+    [ruleId: string]: DaysToDecay;
+  }
 }
 
 // do I need this here?

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,8 +56,8 @@ export interface DaysToDecay {
 }
 
 export interface TodoConfig {
-  daysToDecay: DaysToDecay;
-  decayDaysByRule: {
+  daysToDecay?: DaysToDecay;
+  daysToDecayByRule?: {
     [ruleId: string]: DaysToDecay;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,6 @@ export interface TodoConfig {
  */
 export interface WriteTodoOptions {
   filePath: string;
-  todoConfig: TodoConfig;
+  todoConfig: TodoConfig["daysToDecay"];
   shouldRemove: (todoDatum: TodoData) => boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,9 +48,18 @@ export type LintTodoPackageJson = PackageJson & {
   lintTodo?: { daysToDecay: TodoConfig };
 };
 
+// should I do something like LintTodoPackageJson for the .lint-todorc.js file?
+
 export type TodoBatchCounts = [number, number];
 
 export interface TodoConfig {
+  warn?: number;
+  error?: number;
+}
+
+// do I need this here?
+export interface TodoConfigByRule {
+  ruleId?: string;
   warn?: number;
   error?: number;
 }


### PR DESCRIPTION
Work in Progress

If merged, this PR will add support for decay days to be set per rule in either the `package.json` or a new separate file, `.lint-todorc.js` file.

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.