### PR TITLE
Extends todo configuration to support configuring days to decay by rule ID.

### DIFF
--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -18,7 +18,10 @@ export class FakeProject extends Project {
     this.writeSync();
   }
 
-  writeTodoConfig(daysToDecay: DaysToDecay, daysToDecayByRule?: DaysToDecayByRule): void {
+  writePackageJsonTodoConfig(
+    daysToDecay: DaysToDecay,
+    daysToDecayByRule?: DaysToDecayByRule
+  ): void {
     const todoConfig: {
       lintTodo: TodoConfig;
     } = {
@@ -34,5 +37,20 @@ export class FakeProject extends Project {
     this.pkg = Object.assign({}, this.pkg, todoConfig);
 
     this.writeSync();
+  }
+
+  writeLintTodorc(daysToDecay: DaysToDecay, daysToDecayByRule?: DaysToDecayByRule): void {
+    const todoConfig: TodoConfig = {
+      daysToDecay,
+    };
+
+    if (daysToDecayByRule) {
+      todoConfig.daysToDecayByRule = daysToDecayByRule;
+    }
+
+    this.write({
+      // eslint-disable-next-line unicorn/no-null
+      '.lint-todorc.js': `module.exports = ${JSON.stringify(todoConfig, null, 2)}`,
+    });
   }
 }

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -1,6 +1,6 @@
 import type { DirJSON } from 'fixturify';
 import Project from 'fixturify-project';
-import { DaysToDecay, DaysToDecayByRule, TodoConfig } from '../../src';
+import { DaysToDecay, DaysToDecayByRule, TodoConfig, TodoConfigByEngine } from '../../src';
 
 export class FakeProject extends Project {
   constructor(name = 'fake-project', ...args: any[]) {
@@ -39,13 +39,43 @@ export class FakeProject extends Project {
     this.writeSync();
   }
 
-  writeLintTodorc(daysToDecay: DaysToDecay, daysToDecayByRule?: DaysToDecayByRule): void {
-    const todoConfig: TodoConfig = {
-      daysToDecay,
+  writePackageJsonTodoConfig(
+    engine: string,
+    daysToDecay: DaysToDecay,
+    daysToDecayByRule?: DaysToDecayByRule
+  ): void {
+    const todoConfig: {
+      lintTodo: TodoConfigByEngine;
+    } = {
+      lintTodo: {
+        [engine]: {
+          daysToDecay,
+        },
+      },
     };
 
     if (daysToDecayByRule) {
-      todoConfig.daysToDecayByRule = daysToDecayByRule;
+      todoConfig.lintTodo[engine].daysToDecayByRule = daysToDecayByRule;
+    }
+
+    this.pkg = Object.assign({}, this.pkg, todoConfig);
+
+    this.writeSync();
+  }
+
+  writeLintTodorc(
+    engine: string,
+    daysToDecay: DaysToDecay,
+    daysToDecayByRule?: DaysToDecayByRule
+  ): void {
+    const todoConfig: TodoConfigByEngine = {
+      [engine]: {
+        daysToDecay,
+      },
+    };
+
+    if (daysToDecayByRule) {
+      todoConfig[engine].daysToDecayByRule = daysToDecayByRule;
     }
 
     this.write({

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -18,7 +18,7 @@ export class FakeProject extends Project {
     this.writeSync();
   }
 
-  writePackageJsonTodoConfig(
+  writeLegacyPackageJsonTodoConfig(
     daysToDecay: DaysToDecay,
     daysToDecayByRule?: DaysToDecayByRule
   ): void {

--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -1,6 +1,6 @@
 import type { DirJSON } from 'fixturify';
 import Project from 'fixturify-project';
-import { TodoConfig } from '../../src';
+import { DaysToDecay, DaysToDecayByRule, TodoConfig } from '../../src';
 
 export class FakeProject extends Project {
   constructor(name = 'fake-project', ...args: any[]) {
@@ -18,12 +18,20 @@ export class FakeProject extends Project {
     this.writeSync();
   }
 
-  writeTodoConfig(todoConfig: TodoConfig): void {
-    this.pkg = Object.assign({}, this.pkg, {
+  writeTodoConfig(daysToDecay: DaysToDecay, daysToDecayByRule?: DaysToDecayByRule): void {
+    const todoConfig: {
+      lintTodo: TodoConfig;
+    } = {
       lintTodo: {
-        daysToDecay: todoConfig,
+        daysToDecay,
       },
-    });
+    };
+
+    if (daysToDecayByRule) {
+      todoConfig.lintTodo.daysToDecayByRule = daysToDecayByRule;
+    }
+
+    this.pkg = Object.assign({}, this.pkg, todoConfig);
 
     this.writeSync();
   }

--- a/__tests__/builders-test.ts
+++ b/__tests__/builders-test.ts
@@ -83,14 +83,18 @@ describe('builders', () => {
     });
 
     it('can build todo data from results with days to decay warn only', () => {
-      const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), { warn: 30 });
+      const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), {
+        daysToDecay: { warn: 30 },
+      });
       const todoDatum: TodoData = todoData.values().next().value;
 
       expect(differenceInDays(todoDatum.warnDate!, todoDatum.createdDate)).toEqual(30);
     });
 
     it('can build todo data from results with days to decay error only', () => {
-      const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), { error: 30 });
+      const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), {
+        daysToDecay: { error: 30 },
+      });
       const todoDatum: TodoData = todoData.values().next().value;
 
       expect(differenceInDays(todoDatum.errorDate!, todoDatum.createdDate)).toEqual(30);
@@ -98,8 +102,10 @@ describe('builders', () => {
 
     it('can build todo data from results with days to decay warn and error', () => {
       const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), {
-        warn: 30,
-        error: 60,
+        daysToDecay: {
+          warn: 30,
+          error: 60,
+        },
       });
       const todoDatum: TodoData = todoData.values().next().value;
 
@@ -110,7 +116,9 @@ describe('builders', () => {
     it('can build todo data with a custom createdDate', () => {
       process.env.TODO_CREATED_DATE = new Date(2015, 1, 23).toJSON();
 
-      const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), { warn: 30 });
+      const todoData = buildTodoData(tmp, getFixture('eslint-single-error', tmp), {
+        daysToDecay: { warn: 30 },
+      });
       const todoDatum: TodoData = todoData.values().next().value;
 
       expect(todoDatum.createdDate).toEqual(getDatePart(new Date(2015, 1, 23)).getTime());
@@ -181,7 +189,9 @@ describe('builders', () => {
 
     it('can build todo data from results with days to decay warn only', () => {
       const todoData = buildTodoData(tmp, getFixture('ember-template-lint-single-error', tmp), {
-        warn: 30,
+        daysToDecay: {
+          warn: 30,
+        },
       });
       const todoDatum: TodoData = todoData.values().next().value;
 
@@ -190,7 +200,9 @@ describe('builders', () => {
 
     it('can build todo data from results with days to decay error only', () => {
       const todoData = buildTodoData(tmp, getFixture('ember-template-lint-single-error', tmp), {
-        error: 30,
+        daysToDecay: {
+          error: 30,
+        },
       });
       const todoDatum: TodoData = todoData.values().next().value;
 
@@ -199,8 +211,10 @@ describe('builders', () => {
 
     it('can build todo data from results with days to decay warn and error', () => {
       const todoData = buildTodoData(tmp, getFixture('ember-template-lint-single-error', tmp), {
-        warn: 30,
-        error: 60,
+        daysToDecay: {
+          warn: 30,
+          error: 60,
+        },
       });
       const todoDatum: TodoData = todoData.values().next().value;
 

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -148,7 +148,7 @@ describe('todo-config', () => {
       expect(() => {
         getTodoConfig(project.baseDir);
       }).toThrow(
-        'You cannot have todo configuratons in both package.json and .lint-todorc.js. Please move the configurations from the package.json to the .lint-todorc.js'
+        'You cannot have todo configurations in both package.json and .lint-todorc.js. Please move the configuration from the package.json to the .lint-todorc.js'
       );
     });
 

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -21,7 +21,7 @@ describe('todo-config', () => {
     it('returns default object when no package.json found', async () => {
       await unlink(join(project.baseDir, 'package.json'));
 
-      expect(getTodoConfig(project.baseDir)).toEqual({
+      expect(getTodoConfig(project.baseDir).daysToDecay).toEqual({
         warn: 30,
         error: 60,
       });
@@ -30,7 +30,7 @@ describe('todo-config', () => {
     it('returns default object when no lint todo config found', () => {
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 30,
         error: 60,
       });
@@ -41,7 +41,7 @@ describe('todo-config', () => {
 
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({});
+      expect(config.daysToDecay).toEqual({});
     });
 
     it('can get lint todo config from package.json', () => {
@@ -52,7 +52,7 @@ describe('todo-config', () => {
 
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 5,
         error: 10,
       });
@@ -63,7 +63,7 @@ describe('todo-config', () => {
 
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({ warn: 20, error: 40 });
+      expect(config.daysToDecay).toEqual({ warn: 20, error: 40 });
     });
 
     it('errors if both package.json and .lint-todorc.js contain todo configurations', () => {
@@ -86,7 +86,7 @@ describe('todo-config', () => {
 
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 5,
         error: 10,
       });
@@ -95,7 +95,7 @@ describe('todo-config', () => {
     it('can get lint todo config from options', () => {
       const config = getTodoConfig(project.baseDir, { warn: 3, error: 5 });
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 3,
         error: 5,
       });
@@ -112,7 +112,7 @@ describe('todo-config', () => {
 
       const config = getTodoConfig(project.baseDir);
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 5,
         error: 10,
       });
@@ -129,7 +129,7 @@ describe('todo-config', () => {
         error: 10,
       });
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 5,
         error: 10,
       });
@@ -144,7 +144,7 @@ describe('todo-config', () => {
         error: 10,
       });
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 5,
         error: 10,
       });
@@ -161,7 +161,7 @@ describe('todo-config', () => {
         error: undefined,
       });
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: undefined,
         error: undefined,
       });
@@ -177,7 +177,7 @@ describe('todo-config', () => {
         error: undefined,
       });
 
-      expect(config).toEqual({
+      expect(config.daysToDecay).toEqual({
         warn: 1,
         error: undefined,
       });

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -66,12 +66,76 @@ describe('todo-config', () => {
       });
     });
 
+    it('can get lint todo config from package.json with decay days by rule', () => {
+      project.writePackageJsonTodoConfig(
+        {
+          warn: 5,
+          error: 10,
+        },
+        {
+          'no-bare-strings': {
+            warn: 10,
+            error: 20,
+          },
+        }
+      );
+
+      const config = getTodoConfig(project.baseDir);
+
+      expect(config).toMatchInlineSnapshot(`
+        Object {
+          "daysToDecay": Object {
+            "error": 10,
+            "warn": 5,
+          },
+          "daysToDecayByRule": Object {
+            "no-bare-strings": Object {
+              "error": 20,
+              "warn": 10,
+            },
+          },
+        }
+      `);
+    });
+
     it('can get lint todo config from .lint-todorc.js', () => {
       project.writeLintTodorc({ warn: 20, error: 40 });
 
       const config = getTodoConfig(project.baseDir);
 
       expect(config.daysToDecay).toEqual({ warn: 20, error: 40 });
+    });
+
+    it('can get lint todo config from .lint-todorc.js with decay days by rule', () => {
+      project.writePackageJsonTodoConfig(
+        {
+          warn: 5,
+          error: 10,
+        },
+        {
+          'no-bare-strings': {
+            warn: 10,
+            error: 20,
+          },
+        }
+      );
+
+      const config = getTodoConfig(project.baseDir);
+
+      expect(config).toMatchInlineSnapshot(`
+        Object {
+          "daysToDecay": Object {
+            "error": 10,
+            "warn": 5,
+          },
+          "daysToDecayByRule": Object {
+            "no-bare-strings": Object {
+              "error": 20,
+              "warn": 10,
+            },
+          },
+        }
+      `);
     });
 
     it('errors if both package.json and .lint-todorc.js contain todo configurations', () => {

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -20,7 +20,7 @@ describe('todo-config', () => {
   describe('getTodoConfig', () => {
     it('returns default object when no package.json found', async () => {
       await unlink(join(project.baseDir, 'package.json'));
-      debugger;
+
       expect(getTodoConfig(project.baseDir).daysToDecay).toEqual({
         warn: 30,
         error: 60,
@@ -29,7 +29,7 @@ describe('todo-config', () => {
 
     it('returns default object when no lint todo config found', () => {
       const config = getTodoConfig(project.baseDir);
-      debugger;
+
       expect(config.daysToDecay).toEqual({
         warn: 30,
         error: 60,

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -107,7 +107,7 @@ describe('todo-config', () => {
     });
 
     it('can get lint todo config from .lint-todorc.js with decay days by rule', () => {
-      project.writePackageJsonTodoConfig(
+      project.writeLintTodorc(
         {
           warn: 5,
           error: 10,

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -36,13 +36,13 @@ describe('todo-config', () => {
       });
     });
 
-    it('can return empty lint todo config from package.json when empty config explicitly configured', () => {
-      project.writePackageJsonTodoConfig({});
+    // it('can return empty lint todo config from package.json when empty config explicitly configured', () => {
+    //   project.writeLegacyPackageJsonTodoConfig({});
 
-      const config = getTodoConfig(project.baseDir);
+    //   const config = getTodoConfig(project.baseDir);
 
-      expect(config.daysToDecay).toEqual({});
-    });
+    //   expect(config.daysToDecay).toEqual({});
+    // });
 
     it('can return empty lint todo config from .lint-todorc.js when empty config explicitly configured', () => {
       project.writeLintTodorc({});
@@ -53,7 +53,7 @@ describe('todo-config', () => {
     });
 
     it('can get lint todo config from package.json', () => {
-      project.writePackageJsonTodoConfig({
+      project.writeLegacyPackageJsonTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -67,7 +67,7 @@ describe('todo-config', () => {
     });
 
     it('can get lint todo config from package.json with decay days by rule', () => {
-      project.writePackageJsonTodoConfig(
+      project.writeLegacyPackageJsonTodoConfig(
         {
           warn: 5,
           error: 10,
@@ -139,7 +139,7 @@ describe('todo-config', () => {
     });
 
     it('errors if both package.json and .lint-todorc.js contain todo configurations', () => {
-      project.writePackageJsonTodoConfig({
+      project.writeLegacyPackageJsonTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -174,7 +174,7 @@ describe('todo-config', () => {
     });
 
     it('can override lint todo config from package.json with env vars', () => {
-      project.writePackageJsonTodoConfig({
+      project.writeLegacyPackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -191,7 +191,7 @@ describe('todo-config', () => {
     });
 
     it('can override lint todo config from package.json with options', () => {
-      project.writePackageJsonTodoConfig({
+      project.writeLegacyPackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -223,7 +223,7 @@ describe('todo-config', () => {
     });
 
     it('can override defaults with null values', () => {
-      project.writePackageJsonTodoConfig({
+      project.writeLegacyPackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -240,7 +240,7 @@ describe('todo-config', () => {
     });
 
     it('can override defaults with single null value', () => {
-      project.writePackageJsonTodoConfig({
+      project.writeLegacyPackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -265,6 +265,111 @@ describe('todo-config', () => {
       expect(() => getTodoConfig(project.baseDir, { warn: 10, error: 5 })).toThrow(
         'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
       );
+    });
+
+    describe('legacy configuration', () => {
+      it('can return empty lint todo config from package.json when empty config explicitly configured', () => {
+        project.writeLegacyPackageJsonTodoConfig({});
+
+        const config = getTodoConfig(project.baseDir);
+
+        expect(config.daysToDecay).toEqual({});
+      });
+
+      it('can get lint todo config from package.json', () => {
+        project.writeLegacyPackageJsonTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        const config = getTodoConfig(project.baseDir);
+
+        expect(config.daysToDecay).toEqual({
+          warn: 5,
+          error: 10,
+        });
+      });
+
+      it('errors if both package.json and .lint-todorc.js contain todo configurations', () => {
+        project.writeLegacyPackageJsonTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+        project.writeLintTodorc({ warn: 20, error: 40 });
+
+        expect(() => {
+          getTodoConfig(project.baseDir);
+        }).toThrow(
+          'You cannot have todo configurations in both package.json and .lint-todorc.js. Please move the configuration from the package.json to the .lint-todorc.js'
+        );
+      });
+
+      it('can override lint todo config from package.json with env vars', () => {
+        project.writeLegacyPackageJsonTodoConfig({
+          warn: 1,
+          error: 2,
+        });
+
+        setupEnvVar('TODO_DAYS_TO_WARN', '5');
+        setupEnvVar('TODO_DAYS_TO_ERROR', '10');
+
+        const config = getTodoConfig(project.baseDir);
+
+        expect(config.daysToDecay).toEqual({
+          warn: 5,
+          error: 10,
+        });
+      });
+
+      it('can override lint todo config from package.json with options', () => {
+        project.writeLegacyPackageJsonTodoConfig({
+          warn: 1,
+          error: 2,
+        });
+
+        const config = getTodoConfig(project.baseDir, {
+          warn: 5,
+          error: 10,
+        });
+
+        expect(config.daysToDecay).toEqual({
+          warn: 5,
+          error: 10,
+        });
+      });
+
+      it('can override defaults with null values', () => {
+        project.writeLegacyPackageJsonTodoConfig({
+          warn: 1,
+          error: 2,
+        });
+
+        const config = getTodoConfig(project.baseDir, {
+          warn: undefined,
+          error: undefined,
+        });
+
+        expect(config.daysToDecay).toEqual({
+          warn: undefined,
+          error: undefined,
+        });
+      });
+
+      it('can override defaults with single null value', () => {
+        project.writeLegacyPackageJsonTodoConfig({
+          warn: 1,
+          error: 2,
+        });
+
+        const config = getTodoConfig(project.baseDir, {
+          error: undefined,
+        });
+
+        expect(config.daysToDecay).toEqual({
+          warn: 1,
+          error: undefined,
+        });
+      });
     });
   });
 });

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -37,7 +37,7 @@ describe('todo-config', () => {
     });
 
     it('can returns empty lint todo config from package.json when empty config explicitly configured', () => {
-      project.writeTodoConfig({});
+      project.writePackageJsonTodoConfig({});
 
       const config = getTodoConfig(project.baseDir);
 
@@ -45,7 +45,7 @@ describe('todo-config', () => {
     });
 
     it('can get lint todo config from package.json', () => {
-      project.writeTodoConfig({
+      project.writePackageJsonTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -56,6 +56,28 @@ describe('todo-config', () => {
         warn: 5,
         error: 10,
       });
+    });
+
+    it('can get lint todo config from .lint-todorc.js', () => {
+      project.writeLintTodorc({ warn: 20, error: 40 });
+
+      const config = getTodoConfig(project.baseDir);
+
+      expect(config).toEqual({ warn: 20, error: 40 });
+    });
+
+    it('errors if both package.json and .lint-todorc.js contain todo configurations', () => {
+      project.writePackageJsonTodoConfig({
+        warn: 5,
+        error: 10,
+      });
+      project.writeLintTodorc({ warn: 20, error: 40 });
+
+      expect(() => {
+        getTodoConfig(project.baseDir);
+      }).toThrow(
+        'You cannot have todo configuratons in both package.json and .lint-todorc.js. Please move the configurations from the package.json to the .lint-todorc.js'
+      );
     });
 
     it('can get lint todo config from env vars', () => {
@@ -80,7 +102,7 @@ describe('todo-config', () => {
     });
 
     it('can override lint todo config from package.json with env vars', () => {
-      project.writeTodoConfig({
+      project.writePackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -97,7 +119,7 @@ describe('todo-config', () => {
     });
 
     it('can override lint todo config from package.json with options', () => {
-      project.writeTodoConfig({
+      project.writePackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -129,7 +151,7 @@ describe('todo-config', () => {
     });
 
     it('can override defaults with null values', () => {
-      project.writeTodoConfig({
+      project.writePackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });
@@ -146,7 +168,7 @@ describe('todo-config', () => {
     });
 
     it('can override defaults with single null value', () => {
-      project.writeTodoConfig({
+      project.writePackageJsonTodoConfig({
         warn: 1,
         error: 2,
       });

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -36,8 +36,16 @@ describe('todo-config', () => {
       });
     });
 
-    it('can returns empty lint todo config from package.json when empty config explicitly configured', () => {
+    it('can return empty lint todo config from package.json when empty config explicitly configured', () => {
       project.writePackageJsonTodoConfig({});
+
+      const config = getTodoConfig(project.baseDir);
+
+      expect(config.daysToDecay).toEqual({});
+    });
+
+    it('can return empty lint todo config from .lint-todorc.js when empty config explicitly configured', () => {
+      project.writeLintTodorc({});
 
       const config = getTodoConfig(project.baseDir);
 

--- a/__tests__/todo-config-test.ts
+++ b/__tests__/todo-config-test.ts
@@ -20,7 +20,7 @@ describe('todo-config', () => {
   describe('getTodoConfig', () => {
     it('returns default object when no package.json found', async () => {
       await unlink(join(project.baseDir, 'package.json'));
-
+      debugger;
       expect(getTodoConfig(project.baseDir).daysToDecay).toEqual({
         warn: 30,
         error: 60,
@@ -29,7 +29,7 @@ describe('todo-config', () => {
 
     it('returns default object when no lint todo config found', () => {
       const config = getTodoConfig(project.baseDir);
-
+      debugger;
       expect(config.daysToDecay).toEqual({
         warn: 30,
         error: 60,

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
 import { todoFilePathFor } from './io';
-import { TodoConfig, FilePath, LintMessage, LintResult, TodoData } from './types';
+import { DaysToDecay, FilePath, LintMessage, LintResult, TodoData } from './types';
 import { getDatePart } from './date-utils';
 
 /**
@@ -15,7 +15,7 @@ import { getDatePart } from './date-utils';
 export function buildTodoData(
   baseDir: string,
   lintResults: LintResult[],
-  todoConfig?: TodoConfig
+  todoConfig?: DaysToDecay
 ): Map<FilePath, TodoData> {
   const results = lintResults.filter((result) => result.messages.length > 0);
 
@@ -48,7 +48,7 @@ export function _buildTodoDatum(
   baseDir: string,
   lintResult: LintResult,
   lintMessage: LintMessage,
-  todoConfig?: TodoConfig
+  todoConfig?: DaysToDecay
 ): TodoData {
   // Note: If https://github.com/nodejs/node/issues/13683 is fixed, remove slash() and use posix.relative
   // provided that the fix is landed on the supported node versions of this lib

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
 import { todoFilePathFor } from './io';
-import { DaysToDecay, FilePath, LintMessage, LintResult, TodoData } from './types';
+import { DaysToDecay, FilePath, LintMessage, LintResult, TodoConfig, TodoData } from './types';
 import { getDatePart } from './date-utils';
 
 /**
@@ -15,7 +15,7 @@ import { getDatePart } from './date-utils';
 export function buildTodoData(
   baseDir: string,
   lintResults: LintResult[],
-  todoConfig?: DaysToDecay
+  todoConfig?: TodoConfig
 ): Map<FilePath, TodoData> {
   const results = lintResults.filter((result) => result.messages.length > 0);
 
@@ -48,7 +48,7 @@ export function _buildTodoDatum(
   baseDir: string,
   lintResult: LintResult,
   lintMessage: LintMessage,
-  todoConfig?: DaysToDecay
+  todoConfig?: TodoConfig
 ): TodoData {
   // Note: If https://github.com/nodejs/node/issues/13683 is fixed, remove slash() and use posix.relative
   // provided that the fix is landed on the supported node versions of this lib
@@ -56,6 +56,7 @@ export function _buildTodoDatum(
   const filePath = isAbsolute(lintResult.filePath)
     ? relative(baseDir, lintResult.filePath)
     : lintResult.filePath;
+  const ruleId = getRuleId(lintMessage);
   const todoDatum: TodoData = {
     engine: getEngine(lintResult),
     filePath: slash(filePath),
@@ -65,15 +66,29 @@ export function _buildTodoDatum(
     createdDate: createdDate.getTime(),
   };
 
-  if (todoConfig?.warn) {
-    todoDatum.warnDate = addDays(createdDate, todoConfig.warn).getTime();
+  const daysToDecay: DaysToDecay | undefined = getDaysToDecay(ruleId, todoConfig);
+
+  if (daysToDecay?.warn) {
+    todoDatum.warnDate = addDays(createdDate, daysToDecay.warn).getTime();
   }
 
-  if (todoConfig?.error) {
-    todoDatum.errorDate = addDays(createdDate, todoConfig.error).getTime();
+  if (daysToDecay?.error) {
+    todoDatum.errorDate = addDays(createdDate, daysToDecay.error).getTime();
   }
 
   return todoDatum;
+}
+
+function getDaysToDecay(ruleId: string, todoConfig?: TodoConfig) {
+  if (!todoConfig) {
+    return;
+  }
+
+  if (todoConfig?.daysToDecayByRule && todoConfig.daysToDecayByRule[ruleId]) {
+    return todoConfig.daysToDecayByRule[ruleId];
+  } else if (todoConfig?.daysToDecay) {
+    return todoConfig.daysToDecay;
+  }
 }
 
 function getEngine(result: LintResult) {

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -73,7 +73,7 @@ function getFromConfigFile(basePath: string): TodoConfig | undefined {
 
   if (pkg?.lintTodo && lintTodorc) {
     throw new Error(
-      'You cannot have todo configuratons in both package.json and .lint-todorc.js. Please move the configurations from the package.json to the .lint-todorc.js'
+      'You cannot have todo configurations in both package.json and .lint-todorc.js. Please move the configuration from the package.json to the .lint-todorc.js'
     );
   }
 

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { DaysToDecay } from './types';
+import { DaysToDecay, TodoConfig } from './types';
 
 /**
  * Gets the todo configuration.
@@ -33,18 +33,18 @@ export function getTodoConfig(
   baseDir: string,
   customDaysToDecay: DaysToDecay = {}
 ): DaysToDecay | undefined {
-  const daysToDecayPackageConfig = getFromConfigFile(baseDir);
+  const todoConfig = getFromConfigFile(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
   let mergedConfig = Object.assign(
     {},
-    daysToDecayPackageConfig,
+    todoConfig?.daysToDecay,
     daysToDecayEnvVars,
     customDaysToDecay
   );
 
   // we set a default config if the mergedConfig is an empty object, meaning either or both warn and error aren't
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig)
-  if (Object.keys(mergedConfig).length === 0 && typeof daysToDecayPackageConfig === 'undefined') {
+  if (Object.keys(mergedConfig).length === 0 && typeof todoConfig === 'undefined') {
     mergedConfig = {
       warn: 30,
       error: 60,
@@ -64,7 +64,7 @@ export function getTodoConfig(
   return mergedConfig;
 }
 
-function getFromConfigFile(basePath: string): DaysToDecay | undefined {
+function getFromConfigFile(basePath: string): TodoConfig | undefined {
   const pkg = requireFile(basePath, 'package.json');
   const lintTodorc = requireFile(basePath, '.lint-todorc.js');
 
@@ -74,7 +74,7 @@ function getFromConfigFile(basePath: string): DaysToDecay | undefined {
     );
   }
 
-  return lintTodorc ?? pkg?.lintTodo?.daysToDecay;
+  return lintTodorc ?? pkg?.lintTodo;
 }
 
 function requireFile(basePath: string, fileName: string) {

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { TodoConfig } from './types';
+import { DaysToDecay } from './types';
 
 /**
  * Gets the todo configuration.
@@ -31,8 +31,8 @@ import { TodoConfig } from './types';
  */
 export function getTodoConfig(
   baseDir: string,
-  todoConfig: TodoConfig = {}
-): TodoConfig | undefined {
+  todoConfig: DaysToDecay = {}
+): DaysToDecay | undefined {
   const daysToDecayPackageConfig = getFromPackageJson(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
   let mergedConfig = Object.assign({}, daysToDecayPackageConfig, daysToDecayEnvVars, todoConfig);
@@ -59,7 +59,7 @@ export function getTodoConfig(
   return mergedConfig;
 }
 
-function getFromPackageJson(basePath: string): TodoConfig | undefined {
+function getFromPackageJson(basePath: string): DaysToDecay | undefined {
   let pkg;
 
   try {
@@ -70,8 +70,8 @@ function getFromPackageJson(basePath: string): TodoConfig | undefined {
   return pkg?.lintTodo?.daysToDecay;
 }
 
-function getFromEnvVars(): TodoConfig {
-  const config: TodoConfig = {};
+function getFromEnvVars(): DaysToDecay {
+  const config: DaysToDecay = {};
 
   const warn = getEnvVar('TODO_DAYS_TO_WARN');
   const error = getEnvVar('TODO_DAYS_TO_ERROR');

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -14,7 +14,25 @@ import { DaysToDecay, TodoConfig } from './types';
  *     "daysToDecay": {
  *       "warn": 5,
  *       "error": 10
+ *     },
+ *     "daysToDecayByRule": {
+ *       "no-bare-strings": { "warn": 10, "error": 20 }
  *     }
+ *   }
+ * }
+ * ```
+ *
+ * A .lint-todorc.js file
+ *
+ * @example
+ * ```js
+ * module.exports = {
+ *   "daysToDecay": {
+ *     "warn": 5,
+ *     "error": 10
+ *   },
+ *   "daysToDecayByRule": {
+ *     "no-bare-strings": { "warn": 10, "error": 20 }
  *   }
  * }
  * ```

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -30,7 +30,7 @@ import { DaysToDecay, TodoConfig } from './types';
  * @returns - The todo config object.
  */
 export function getTodoConfig(baseDir: string, customDaysToDecay: DaysToDecay = {}): TodoConfig {
-  const todoConfig = getFromConfigFile(baseDir);
+  let todoConfig = getFromConfigFile(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
   let mergedDaysToDecay = Object.assign(
     {},
@@ -58,9 +58,13 @@ export function getTodoConfig(baseDir: string, customDaysToDecay: DaysToDecay = 
     );
   }
 
-  return {
-    daysToDecay: mergedDaysToDecay,
-  };
+  if (!todoConfig) {
+    todoConfig = {};
+  }
+
+  todoConfig.daysToDecay = mergedDaysToDecay;
+
+  return todoConfig;
 }
 
 function getFromConfigFile(basePath: string): TodoConfig | undefined {

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -11,12 +11,14 @@ import { DaysToDecay, TodoConfig } from './types';
  * ```json
  * {
  *   "lintTodo": {
- *     "daysToDecay": {
- *       "warn": 5,
- *       "error": 10
- *     },
- *     "daysToDecayByRule": {
- *       "no-bare-strings": { "warn": 10, "error": 20 }
+ *     "some-engine": {
+ *       "daysToDecay": {
+ *         "warn": 5,
+ *         "error": 10
+ *       },
+ *       "daysToDecayByRule": {
+ *         "no-bare-strings": { "warn": 10, "error": 20 }
+ *       }
  *     }
  *   }
  * }
@@ -27,12 +29,14 @@ import { DaysToDecay, TodoConfig } from './types';
  * @example
  * ```js
  * module.exports = {
- *   "daysToDecay": {
- *     "warn": 5,
- *     "error": 10
- *   },
- *   "daysToDecayByRule": {
- *     "no-bare-strings": { "warn": 10, "error": 20 }
+ *   "some-engine": {
+ *     "daysToDecay": {
+ *       "warn": 5,
+ *       "error": 10
+ *     },
+ *     "daysToDecayByRule": {
+ *       "no-bare-strings": { "warn": 10, "error": 20 }
+ *     }
  *   }
  * }
  * ```

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -26,16 +26,21 @@ import { DaysToDecay } from './types';
  * 	- Passed in options override both env vars and package.json config
  *
  * @param baseDir - The base directory that contains the project's package.json.
- * @param todoConfig - The optional todo configuration.
+ * @param customDaysToDecay - The optional custom days to decay configuration.
  * @returns - The todo config object.
  */
 export function getTodoConfig(
   baseDir: string,
-  todoConfig: DaysToDecay = {}
+  customDaysToDecay: DaysToDecay = {}
 ): DaysToDecay | undefined {
   const daysToDecayPackageConfig = getFromPackageJson(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
-  let mergedConfig = Object.assign({}, daysToDecayPackageConfig, daysToDecayEnvVars, todoConfig);
+  let mergedConfig = Object.assign(
+    {},
+    daysToDecayPackageConfig,
+    daysToDecayEnvVars,
+    customDaysToDecay
+  );
 
   // we set a default config if the mergedConfig is an empty object, meaning either or both warn and error aren't
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig)

--- a/src/todo-config.ts
+++ b/src/todo-config.ts
@@ -29,13 +29,10 @@ import { DaysToDecay, TodoConfig } from './types';
  * @param customDaysToDecay - The optional custom days to decay configuration.
  * @returns - The todo config object.
  */
-export function getTodoConfig(
-  baseDir: string,
-  customDaysToDecay: DaysToDecay = {}
-): DaysToDecay | undefined {
+export function getTodoConfig(baseDir: string, customDaysToDecay: DaysToDecay = {}): TodoConfig {
   const todoConfig = getFromConfigFile(baseDir);
   const daysToDecayEnvVars = getFromEnvVars();
-  let mergedConfig = Object.assign(
+  let mergedDaysToDecay = Object.assign(
     {},
     todoConfig?.daysToDecay,
     daysToDecayEnvVars,
@@ -44,24 +41,26 @@ export function getTodoConfig(
 
   // we set a default config if the mergedConfig is an empty object, meaning either or both warn and error aren't
   // defined and the package.json doesn't explicitly define an empty config (they're opting out of defining a todoConfig)
-  if (Object.keys(mergedConfig).length === 0 && typeof todoConfig === 'undefined') {
-    mergedConfig = {
+  if (Object.keys(mergedDaysToDecay).length === 0 && typeof todoConfig === 'undefined') {
+    mergedDaysToDecay = {
       warn: 30,
       error: 60,
     };
   }
 
   if (
-    typeof mergedConfig.warn === 'number' &&
-    typeof mergedConfig.error === 'number' &&
-    mergedConfig.warn >= mergedConfig.error
+    typeof mergedDaysToDecay.warn === 'number' &&
+    typeof mergedDaysToDecay.error === 'number' &&
+    mergedDaysToDecay.warn >= mergedDaysToDecay.error
   ) {
     throw new Error(
-      `The provided todo configuration contains invalid values. The \`warn\` value (${mergedConfig.warn}) must be less than the \`error\` value (${mergedConfig.error}).`
+      `The provided todo configuration contains invalid values. The \`warn\` value (${mergedDaysToDecay.warn}) must be less than the \`error\` value (${mergedDaysToDecay.error}).`
     );
   }
 
-  return mergedConfig;
+  return {
+    daysToDecay: mergedDaysToDecay,
+  };
 }
 
 function getFromConfigFile(basePath: string): TodoConfig | undefined {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,12 +45,12 @@ export interface TodoData {
 }
 
 export type LintTodoPackageJson = PackageJson & {
-  lintTodo?: { daysToDecay: TodoConfig };
+  lintTodo?: { daysToDecay: DaysToDecay };
 };
 
 export type TodoBatchCounts = [number, number];
 
-export interface TodoConfig {
+export interface DaysToDecay {
   warn?: number;
   error?: number;
 }
@@ -64,6 +64,6 @@ export interface TodoConfig {
  */
 export interface WriteTodoOptions {
   filePath: string;
-  todoConfig: TodoConfig;
+  todoConfig: DaysToDecay;
   shouldRemove: (todoDatum: TodoData) => boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,6 +73,6 @@ export interface TodoConfig {
  */
 export interface WriteTodoOptions {
   filePath: string;
-  todoConfig: DaysToDecay;
+  todoConfig: TodoConfig;
   shouldRemove: (todoDatum: TodoData) => boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,14 +45,23 @@ export interface TodoData {
 }
 
 export type LintTodoPackageJson = PackageJson & {
-  lintTodo?: { daysToDecay: DaysToDecay };
+  lintTodo?: TodoConfig;
 };
 
 export type TodoBatchCounts = [number, number];
 
-export interface DaysToDecay {
+export type DaysToDecay = {
   warn?: number;
   error?: number;
+};
+
+export type DaysToDecayByRule = {
+  [ruleId: string]: DaysToDecay;
+};
+
+export interface TodoConfig {
+  daysToDecay?: DaysToDecay;
+  daysToDecayByRule?: DaysToDecayByRule;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,7 +45,7 @@ export interface TodoData {
 }
 
 export type LintTodoPackageJson = PackageJson & {
-  lintTodo?: TodoConfig;
+  lintTodo?: TodoConfig | TodoConfigByEngine;
 };
 
 export type TodoBatchCounts = [number, number];
@@ -62,6 +62,10 @@ export type DaysToDecayByRule = {
 export interface TodoConfig {
   daysToDecay?: DaysToDecay;
   daysToDecayByRule?: DaysToDecayByRule;
+}
+
+export interface TodoConfigByEngine {
+  [engine: string]: TodoConfig;
 }
 
 /**


### PR DESCRIPTION
Implements https://github.com/ember-template-lint/ember-template-lint/issues/1880

This change adds support for using a config file, `.lint-todorc.js`. This config is a superset of the old config, which was simply:

```json
{
  "lintTodo": {
    "daysToDecay": {
      "warn": 5,
      "error": 10
    }
  }
}
```

The new structure adds a level of nesting, allowing you to specify which `engine` the config section applies to:

```json
 {
   "lintTodo": {
     "some-engine": {
       "daysToDecay": {
         "warn": 5,
         "error": 10
       },
       "daysToDecayByRule": {
         "no-bare-strings": { "warn": 10, "error": 20 }
       }
     }
   }
 }
```
 In addition, you can now configure `daysToDecay` by ruleID, allowing more fine-grained configuration of decay dates. It also provides a single source of truth for configuring those dates.

As of this change, we now support

1. Legacy configs, such as those in the first example above
2. Configuration in `package.json`
3. Configuration in `.lint-todorc.js`

From a consumer perspective, the main change to the public API surface area is a change to the `getTodoConfig` signature, which now accepts a required `engine` parameter.

```ts
export function getTodoConfig(
  baseDir: string,
  engine: string,
  customDaysToDecay: DaysToDecay = {}
): TodoConfig;
```

This function always returns a `TodoConfig`, as before, but now scoped by `engine`.