### PR TITLE
Added support for source-based hash

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -9,6 +9,7 @@ import {
   getTodoBatchesSync,
   todoDirFor,
   todoFileNameFor,
+  todoFileNameForSource,
   todoFilePathFor,
   todoStorageDirExists,
   writeTodos,
@@ -29,6 +30,16 @@ const TODO_DATA: TodoData = {
   ruleId: 'no-prototype-builtins',
   line: 25,
   column: 21,
+  createdDate: getDatePart(new Date('12/11/2020')).getTime(),
+};
+
+const TODO_TEMPLATE_DATA: TodoData = {
+  engine: 'ember-template-lint',
+  filePath: 'app/templates/components/add-ssh-key.hbs',
+  ruleId: 'require-input-label',
+  line: 3,
+  column: 4,
+  source: '<input />',
   createdDate: getDatePart(new Date('12/11/2020')).getTime(),
 };
 
@@ -85,6 +96,22 @@ describe('io', () => {
 
       expect(fileName).toEqual('6e3be839');
       expect(secondFileName).toEqual('6e3be839');
+    });
+  });
+
+  describe('todoFileNameForSource', () => {
+    it('can generate a unique hash for todo based on the source', () => {
+      const fileName = todoFileNameForSource(TODO_TEMPLATE_DATA);
+
+      expect(fileName).toEqual('388885f3');
+    });
+
+    it('generates idempotent file names', () => {
+      const fileName = todoFileNameForSource(TODO_TEMPLATE_DATA);
+      const secondFileName = todoFileNameForSource(TODO_TEMPLATE_DATA);
+
+      expect(fileName).toEqual('388885f3');
+      expect(secondFileName).toEqual('388885f3');
     });
   });
 

--- a/__tests__/match-utils-test.ts
+++ b/__tests__/match-utils-test.ts
@@ -1,6 +1,16 @@
-import { isFuzzyMatch } from "../src/match-utils";
+import { isFuzzyMatch, hasFuzzyMatch } from "../src/match-utils";
 import { getDatePart } from '../src/date-utils';
-import { TodoData } from "../src";
+import { TodoData, FilePath } from "../src";
+
+const todoDatumTemplate: TodoData = {
+  engine: 'ember-template-lint',
+  filePath: 'app/components/my-input.hbs',
+  ruleId: 'require-input-label',
+  line: 1,
+  column: 1,
+  createdDate: getDatePart().getTime(),
+  source: '<input/>'
+};
 
 describe('isFuzzyMatch', () => {
   let today: number;
@@ -161,5 +171,76 @@ describe('isFuzzyMatch', () => {
       source: '<input/>'
     }
     expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+  });
+});
+
+describe('isFuzzyMatch from template TodoData objects', () => {
+
+  it('successfully identifies a fuzzy match when the line number has changed', () => {
+    const testTodo: TodoData = todoDatumTemplate;
+    const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { line: 2 } );
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
+  });
+});
+
+describe('hasFuzzyMatch', () => {
+  let today: number;
+  beforeEach(() => {
+    today = getDatePart().getTime();
+  });
+
+    // Relevant properties of default template:
+    //   filePath: 'app/components/my-input.hbs',
+    //   ruleId: 'require-input-label',
+    //   line: 1, column: 1,
+    //   source: '<input/>'
+
+  it('successfully identifies a fuzzy match within a refMap when the line number has changed', () => {
+    const testTodo: TodoData = todoDatumTemplate;
+    const refTodoMap = new Map<FilePath, TodoData>();
+    refTodoMap.set("hash01", Object.assign({}, todoDatumTemplate, { filepath: 'app/components/my-other-input.hbs' } ));
+    refTodoMap.set("hash02", Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule' } ));
+    refTodoMap.set("hash03", Object.assign({}, todoDatumTemplate, { source: '<otherInput>' } ));
+    refTodoMap.set("needle", Object.assign({}, todoDatumTemplate, { line: 2 } ));
+    expect(hasFuzzyMatch(testTodo, refTodoMap)).toEqual(true);
+  });
+
+  it('successfully identifies a fuzzy match within a refMap when the column has changed', () => {
+    const testTodo: TodoData = todoDatumTemplate;
+    const refTodoMap = new Map<FilePath, TodoData>();
+    refTodoMap.set("hash01", Object.assign({}, todoDatumTemplate, { filepath: 'app/components/my-other-input.hbs' } ));
+    refTodoMap.set("hash02", Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule' } ));
+    refTodoMap.set("hash03", Object.assign({}, todoDatumTemplate, { source: '<otherInput>' } ));
+    refTodoMap.set("needle", Object.assign({}, todoDatumTemplate, { column: 2 } ));
+    expect(hasFuzzyMatch(testTodo, refTodoMap)).toEqual(true);
+  });
+
+  it('successfully identifies a fuzzy match within a refMap when the line and column have changed', () => {
+    const testTodo: TodoData = todoDatumTemplate;
+    const refTodoMap = new Map<FilePath, TodoData>();
+    refTodoMap.set("hash01", Object.assign({}, todoDatumTemplate, { filepath: 'app/components/my-other-input.hbs' } ));
+    refTodoMap.set("hash02", Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule' } ));
+    refTodoMap.set("hash03", Object.assign({}, todoDatumTemplate, { source: '<otherInput>' } ));
+    refTodoMap.set("needle", Object.assign({}, todoDatumTemplate, { line: 2, column: 2 } ));
+    expect(hasFuzzyMatch(testTodo, refTodoMap)).toEqual(true);
+  });
+
+  it('does not find a fuzzy match within a refMap containing exclusively todo data that has different filepath/ruleId/source properties', () => {
+    const testTodo: TodoData = todoDatumTemplate;
+    const refTodoMap = new Map<FilePath, TodoData>();
+    refTodoMap.set("hash01", Object.assign({}, todoDatumTemplate, { filepath: 'app/components/my-other-input.hbs' } ));
+    refTodoMap.set("hash02", Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule' } ));
+    refTodoMap.set("hash03", Object.assign({}, todoDatumTemplate, { source: '<otherInput>' } ));
+    expect(hasFuzzyMatch(testTodo, refTodoMap)).toEqual(false);
+  });
+
+  it('does not find a fuzzy match within a refMap containing an exact match', () => {
+    const testTodo: TodoData = todoDatumTemplate;
+    const refTodoMap = new Map<FilePath, TodoData>();
+    refTodoMap.set("hash01", Object.assign({}, todoDatumTemplate, { filepath: 'app/components/my-other-input.hbs' } ));
+    refTodoMap.set("hash02", Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule' } ));
+    refTodoMap.set("hash03", Object.assign({}, todoDatumTemplate, { source: '<otherInput>' } ));
+    refTodoMap.set("needle", Object.assign({}, todoDatumTemplate));
+    expect(hasFuzzyMatch(testTodo, refTodoMap)).toEqual(false);
   });
 });

--- a/__tests__/match-utils-test.ts
+++ b/__tests__/match-utils-test.ts
@@ -96,4 +96,70 @@ describe('isFuzzyMatch', () => {
     }
     expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
   });
+
+  it('does not recognize a fuzzy match if the filePath(s) do not match', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-inputs.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+  });
+
+  it('does not recognize a fuzzy match if the ruleId(s) do not match', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'no-nested-interactive',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+  });
+
+  it('does not recognize a fuzzy match if the source(s) do not match', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<textarea/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+  });
 });

--- a/__tests__/match-utils-test.ts
+++ b/__tests__/match-utils-test.ts
@@ -246,43 +246,43 @@ describe('hasFuzzyMatch', () => {
 });
 
 describe('isFuzzyMatchFromSourceHash', () => {
-    it('successfully identifies a source-hashed fuzzy matchwhen the line number has changed', () => {
+    it('successfully identifies a source-hashed fuzzy match when the line number has changed', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { line: 2 } );
       expect(isFuzzyMatchFromSourceHash(testTodo, refTodo)).toEqual(true);
     });
 
-    it('successfully identifies a source-hashed fuzzy matchwhen the column number has changed', () => {
+    it('successfully identifies a source-hashed fuzzy match when the column number has changed', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { column: 2 } );
       expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
     });
 
-    it('successfully identifies a source-hashed fuzzy matchif both line and column have changed', () => {
+    it('successfully identifies a source-hashed fuzzy match if both line and column have changed', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { line: 2, column: 2 } );
       expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
     });
 
-    it('does not recognize a source-hashed fuzzy matchif they are an exact match', () => {
+    it('does not recognize a source-hashed fuzzy match if they are an exact match', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate );
       expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
     });
 
-    it('does not recognize a source-hashed fuzzy matchif the filePath(s) do not match', () => {
+    it('does not recognize a source-hashed fuzzy match if the filePath(s) do not match', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { filePath: 'app/components/my-other-input.hbs' } );
       expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
     });
 
-    it('does not recognize a source-hashed fuzzy matchif the ruleId(s) do not match', () => {
+    it('does not recognize a source-hashed fuzzy match if the ruleId(s) do not match', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule'  } );
       expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
     });
 
-    it('does not recognize a source-hashed fuzzy matchif the source(s) do not match', () => {
+    it('does not recognize a source-hashed fuzzy match if the source(s) do not match', () => {
       const testTodo: TodoData = todoDatumTemplate;
       const refTodo: TodoData = Object.assign({}, todoDatumTemplate);
       expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);

--- a/__tests__/match-utils-test.ts
+++ b/__tests__/match-utils-test.ts
@@ -1,0 +1,99 @@
+import { isFuzzyMatch } from "../src/match-utils";
+import { getDatePart } from '../src/date-utils';
+import { TodoData } from "../src";
+
+describe('isFuzzyMatch', () => {
+  let today: number;
+
+  beforeEach(() => {
+    today = getDatePart().getTime();
+  });
+
+  it('successfully identifies a fuzzy match when the line number has changed', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 5,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
+  });
+
+  it('successfully identifies a fuzzy match when the column number has changed', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 5,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
+  });
+
+  it('successfully identifies a fuzzy match if both line and column have changed', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 5,
+      column: 5,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
+  });
+
+  it('does not recognize a fuzzy match if they are an exact match', () => {
+    const testTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    const refTodo: TodoData = {
+      engine: 'ember-template-lint',
+      filePath: 'app/components/my-input.hbs',
+      ruleId: 'require-input-label',
+      line: 4,
+      column: 3,
+      createdDate: today,
+      source: '<input/>'
+    }
+    expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+  });
+});

--- a/__tests__/match-utils-test.ts
+++ b/__tests__/match-utils-test.ts
@@ -1,4 +1,4 @@
-import { isFuzzyMatch, hasFuzzyMatch } from "../src/match-utils";
+import { isFuzzyMatch, hasFuzzyMatch, isFuzzyMatchFromSourceHash } from "../src/match-utils";
 import { getDatePart } from '../src/date-utils';
 import { TodoData, FilePath } from "../src";
 
@@ -244,3 +244,48 @@ describe('hasFuzzyMatch', () => {
     expect(hasFuzzyMatch(testTodo, refTodoMap)).toEqual(false);
   });
 });
+
+describe('isFuzzyMatchFromSourceHash', () => {
+    it('successfully identifies a source-hashed fuzzy matchwhen the line number has changed', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { line: 2 } );
+      expect(isFuzzyMatchFromSourceHash(testTodo, refTodo)).toEqual(true);
+    });
+
+    it('successfully identifies a source-hashed fuzzy matchwhen the column number has changed', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { column: 2 } );
+      expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
+    });
+
+    it('successfully identifies a source-hashed fuzzy matchif both line and column have changed', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { line: 2, column: 2 } );
+      expect(isFuzzyMatch(testTodo, refTodo)).toEqual(true);
+    });
+
+    it('does not recognize a source-hashed fuzzy matchif they are an exact match', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate );
+      expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+    });
+
+    it('does not recognize a source-hashed fuzzy matchif the filePath(s) do not match', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { filePath: 'app/components/my-other-input.hbs' } );
+      expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+    });
+
+    it('does not recognize a source-hashed fuzzy matchif the ruleId(s) do not match', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate, { ruleId: 'some-other-rule'  } );
+      expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+    });
+
+    it('does not recognize a source-hashed fuzzy matchif the source(s) do not match', () => {
+      const testTodo: TodoData = todoDatumTemplate;
+      const refTodo: TodoData = Object.assign({}, todoDatumTemplate);
+      expect(isFuzzyMatch(testTodo, refTodo)).toEqual(false);
+    });
+
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   todoStorageDirExists,
   todoDirFor,
   todoFileNameFor,
+  todoFileNameForSource,
   todoFilePathFor,
   readTodos,
   readTodosForFilePath,

--- a/src/io.ts
+++ b/src/io.ts
@@ -103,6 +103,19 @@ export function todoFileNameFor(todoData: TodoData): string {
 }
 
 /**
+ * Generates a unique hash for the filename for a todo lint data based on the violation source.
+ *
+ * @param todoData - The linting data for an individual violation.
+ * @returns  - The todo file name for a {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} object (based on the source, not the line and column).
+ */
+
+export function todoFileNameForSource(todoData: TodoData): string {
+  const hashParams = `${todoData.engine}${todoData.ruleId}${todoData.source}`;
+  console.log(`${todoData.source}`);
+  return createHash('sha256').update(hashParams).digest('hex').slice(0, 8);
+}
+
+/**
  * Writes files for todo lint violations. One file is generated for each violation, using a generated
  * hash to identify each.
  *

--- a/src/io.ts
+++ b/src/io.ts
@@ -379,11 +379,8 @@ export async function getTodoBatches(
         stable.set(fileHash, todoDatum);
     } else if (
       !existing.has(fileHash)
-      // !isFuzzyMatch(todoDatum)
       ) {
         add.set(fileHash, todoDatum);
-    } else {
-      console.log(`a condition is falling through the cracks for add/stable`);
     }
   }
 
@@ -402,12 +399,9 @@ export async function getTodoBatches(
         stable.set(fileHash, todoDatum)
       } else if (
         !lintResults.has(fileHash) &&
-        // !isFuzzyMatch(todoDatum) &&
         options.shouldRemove!(todoDatum)
       ) {
         remove.set(fileHash, todoDatum);
-    } else {
-      console.log(`A condition is falling through the cracks for expired/remove/stable`)
     }
   }
 

--- a/src/match-utils.ts
+++ b/src/match-utils.ts
@@ -1,0 +1,21 @@
+import { TodoData } from './types';
+
+/**
+ * Checks to see if a todo might be a fuzzy match.
+ * @param testTodo - The todo data from the lint results.
+ * @param refTodo - The existing todo data to check against.
+ * @returns true or false - true if filePath, ruleId and source are a match. At least line or column should not match.
+ */
+
+export function isFuzzyMatch(testTodo: TodoData, refTodo: TodoData): boolean {
+  // if the filePath, ruleId and source match
+  if (
+    testTodo.filePath === refTodo.filePath &&
+    testTodo.ruleId === refTodo.ruleId &&
+    testTodo.source === refTodo.source &&
+  // if the line or column (or both) have changed
+    (testTodo.line !== refTodo.line || testTodo.column !== testTodo.column)
+  ) {
+      return true;
+  } return false;
+}

--- a/src/match-utils.ts
+++ b/src/match-utils.ts
@@ -1,4 +1,10 @@
 import { TodoData, FilePath } from './types';
+import {
+	//
+	todoDirFor, // 'app/components/my-input.hbs' -> [folderHash]
+	todoFileNameFor, // TodoDatum -> [folderHash]/[engineRuleIdLineColHash]
+	todoFileNameForSource, // '<input/>' -> [sourceHash]
+} from './io';
 
 /**
  * Checks to see if a todo might be a fuzzy match.
@@ -18,6 +24,17 @@ export function isFuzzyMatch(testTodo: TodoData, refTodo: TodoData): boolean {
   } return false;
 }
 
+// Same as `isFuzzyMatch(testTodo, refTodo)` except its abstracted to the hashing system
+export function isFuzzyMatchFromSourceHash(testTodo: TodoData, refTodo: TodoData): boolean {
+  if (
+    todoDirFor(testTodo.filePath) === todoDirFor(refTodo.filePath) &&
+    todoFileNameForSource(testTodo) === todoFileNameForSource(refTodo) &&
+    (todoFileNameFor(testTodo) !== todoFileNameFor(refTodo))
+  ) {
+    return true;
+  } return false;
+}
+
 /**
  * Checks to see if a todo has a fuzzy match within a reference Map
  * @param testTodo - The todo data needle to look for
@@ -25,6 +42,6 @@ export function isFuzzyMatch(testTodo: TodoData, refTodo: TodoData): boolean {
  * @returns boolean - the testTodo fuzzy matches against at least one todo in the reference Map
  * Note: a fuzzy match is false for an exact match
  */
-export function hasFuzzyMatch(testTodo: TodoData, refTodoMap: Map<FilePath, TodoData>): boolean {
+  export function hasFuzzyMatch(testTodo: TodoData, refTodoMap: Map<FilePath, TodoData>): boolean {
   return [...refTodoMap.values()].some(refTodoDatum => isFuzzyMatch(testTodo, refTodoDatum));
 }

--- a/src/match-utils.ts
+++ b/src/match-utils.ts
@@ -14,7 +14,7 @@ export function isFuzzyMatch(testTodo: TodoData, refTodo: TodoData): boolean {
     testTodo.ruleId === refTodo.ruleId &&
     testTodo.source === refTodo.source &&
   // if the line or column (or both) have changed
-    (testTodo.line !== refTodo.line || testTodo.column !== testTodo.column)
+    (testTodo.line !== refTodo.line || testTodo.column !== refTodo.column)
   ) {
       return true;
   } return false;

--- a/src/match-utils.ts
+++ b/src/match-utils.ts
@@ -1,4 +1,4 @@
-import { TodoData } from './types';
+import { TodoData, FilePath } from './types';
 
 /**
  * Checks to see if a todo might be a fuzzy match.
@@ -8,14 +8,23 @@ import { TodoData } from './types';
  */
 
 export function isFuzzyMatch(testTodo: TodoData, refTodo: TodoData): boolean {
-  // if the filePath, ruleId and source match
   if (
     testTodo.filePath === refTodo.filePath &&
     testTodo.ruleId === refTodo.ruleId &&
     testTodo.source === refTodo.source &&
-  // if the line or column (or both) have changed
     (testTodo.line !== refTodo.line || testTodo.column !== refTodo.column)
   ) {
       return true;
   } return false;
+}
+
+/**
+ * Checks to see if a todo has a fuzzy match within a reference Map
+ * @param testTodo - The todo data needle to look for
+ * @param refTodoMap - The reference Map whose values are the todo haystack to look in
+ * @returns boolean - the testTodo fuzzy matches against at least one todo in the reference Map
+ * Note: a fuzzy match is false for an exact match
+ */
+export function hasFuzzyMatch(testTodo: TodoData, refTodoMap: Map<FilePath, TodoData>): boolean {
+  return [...refTodoMap.values()].some(refTodoDatum => isFuzzyMatch(testTodo, refTodoDatum));
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,7 +74,7 @@ export interface TodoConfigByEngine {
  *
  * @param filePath - The relative file path of the file to update violations for.
  * @param todoConfig - An object containing the warn or error days, in integers.
- * @param skipRemoval - Allows for skipping removal of todo files.
+ * @param shouldRemove - Allows for skipping removal of todo files.
  */
 export interface WriteTodoOptions {
   filePath: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,7 @@ export interface TodoData {
   createdDate: number;
   warnDate?: number;
   errorDate?: number;
+  source?: string;
 }
 
 export type LintTodoPackageJson = PackageJson & {


### PR DESCRIPTION
This PR: 
- Added function to generate source-based hash from a todo datum
- Updated interface to include source as an optional property (to accommodate for eslint)
- Added new template object (with non-trivial source) to tests
- Added tests to verify new source-based hash function
