### PR TITLE
Tweak `getDatePart` to use UTC date

### DIFF
--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -19,5 +19,5 @@ export function isExpired(
  * @returns Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
  */
 export function getDatePart(date: Date = new Date()): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0,0,0));
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0));
 }

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -19,5 +19,5 @@ export function isExpired(
  * @returns Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
  */
 export function getDatePart(date: Date = new Date()): Date {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0,0,0));
 }


### PR DESCRIPTION
Ensures that the date used by `getDatePart` _is_ always going to be the current UTC date (at 12:00:00). Previously, the date we used was the locale date (e.g. it might be 2021-06-09 in PDT but 2021-06-10 in GMT), which would result in incorrectly flagging expired TODO's.

The fundamental constraint that we are going for here, is that if someone in PDT checks if a todo is expired and at _the exact same time_ someone in IST runs the same test: the results should be the same!