### PR TITLE
Adds new date utils: differenceInDays and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Config values can be present in</p>
 <dt><a href="#getDatePart">getDatePart(date)</a> ⇒</dt>
 <dd><p>Converts a date to include year, month, and day values only (time is zeroed out).</p>
 </dd>
+<dt><a href="#differenceInDays">differenceInDays(startDate, endDate)</a> ⇒</dt>
+<dd><p>Returns the difference in days between two dates.</p>
+</dd>
+<dt><a href="#format">format(date)</a> ⇒</dt>
+<dd><p>Formats the date in short form, eg. 2021-01-01</p>
+</dd>
 </dl>
 
 <a name="buildTodoData"></a>
@@ -444,6 +450,31 @@ Converts a date to include year, month, and day values only (time is zeroed out)
 | Param | Description |
 | --- | --- |
 | date | The date to convert |
+
+<a name="differenceInDays"></a>
+
+## differenceInDays(startDate, endDate) ⇒
+Returns the difference in days between two dates.
+
+**Kind**: global function  
+**Returns**: a number representing the days between the dates  
+
+| Param |
+| --- |
+| startDate | 
+| endDate | 
+
+<a name="format"></a>
+
+## format(date) ⇒
+Formats the date in short form, eg. 2021-01-01
+
+**Kind**: global function  
+**Returns**: A string representing the formatted date  
+
+| Param |
+| --- |
+| date | 
 
 
 <!--DOCS_END-->

--- a/__tests__/date-utils-test.ts
+++ b/__tests__/date-utils-test.ts
@@ -1,19 +1,43 @@
 import { subDays, addDays } from 'date-fns';
-import { isExpired, getDatePart } from '../src/date-utils';
+import { isExpired, getDatePart, differenceInDays } from '../src/date-utils';
 
-describe('isExpired', () => {
-  let today: number;
+describe('date-utils', () => {
+  describe('isExpired', () => {
+    let today: number;
 
-  beforeEach(() => {
-    today = getDatePart().getTime();
+    beforeEach(() => {
+      today = getDatePart().getTime();
+    });
+
+    it('returns false when a date is not expired', () => {
+      expect(isExpired(getDatePart().getTime(), today)).toEqual(false);
+      expect(isExpired(addDays(getDatePart(), 1).getTime(), today)).toEqual(false);
+    });
+
+    it('returns true when a date is expired', () => {
+      expect(isExpired(subDays(getDatePart(), 1).getTime(), today)).toEqual(true);
+    });
   });
 
-  it('returns false when a date is not expired', () => {
-    expect(isExpired(getDatePart().getTime(), today)).toEqual(false);
-    expect(isExpired(addDays(getDatePart(), 1).getTime(), today)).toEqual(false);
-  });
+  describe('differenceInDays', () => {
+    it('returns 0 when dates are same', () => {
+      expect(differenceInDays(new Date('2021-01-01'), new Date('2021-01-01'))).toEqual(0);
+    });
 
-  it('returns true when a date is expired', () => {
-    expect(isExpired(subDays(getDatePart(), 1).getTime(), today)).toEqual(true);
+    it('returns 1 when start date is 1 days before end date', () => {
+      expect(differenceInDays(new Date('2021-01-01'), new Date('2021-01-02'))).toEqual(1);
+    });
+
+    it('returns 10 when start date is 10 days before end date', () => {
+      expect(differenceInDays(new Date('2021-01-01'), new Date('2021-01-11'))).toEqual(10);
+    });
+
+    it('returns -1 when start date is past end date', () => {
+      expect(differenceInDays(new Date('2021-01-02'), new Date('2021-01-01'))).toEqual(-1);
+    });
+
+    it('returns -10 when start date is past end date', () => {
+      expect(differenceInDays(new Date('2021-01-11'), new Date('2021-01-01'))).toEqual(-10);
+    });
   });
 });

--- a/__tests__/date-utils-test.ts
+++ b/__tests__/date-utils-test.ts
@@ -1,5 +1,5 @@
 import { subDays, addDays } from 'date-fns';
-import { isExpired, getDatePart, differenceInDays } from '../src/date-utils';
+import { isExpired, getDatePart, differenceInDays, format } from '../src/date-utils';
 
 describe('date-utils', () => {
   describe('isExpired', () => {
@@ -38,6 +38,20 @@ describe('date-utils', () => {
 
     it('returns -10 when start date is past end date', () => {
       expect(differenceInDays(new Date('2021-01-11'), new Date('2021-01-01'))).toEqual(-10);
+    });
+  });
+
+  describe('format', () => {
+    it('returns correctly formatted date for string', () => {
+      expect(format('2021-01-01')).toEqual('2021-01-01');
+    });
+
+    it('returns correctly formatted date for number', () => {
+      expect(format(1609459200000)).toEqual('2021-01-01');
+    });
+
+    it('returns correctly formatted date for date', () => {
+      expect(format(getDatePart(new Date('2021-01-01')))).toEqual('2021-01-01');
     });
   });
 });

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -21,3 +21,11 @@ export function isExpired(
 export function getDatePart(date: Date = new Date()): Date {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0));
 }
+
+export function differenceInDays(startDate: Date, endDate: Date): number {
+  const millisecondsPerDay = 86400000;
+
+  return Math.round(
+    (getDatePart(endDate).getTime() - getDatePart(startDate).getTime()) / millisecondsPerDay
+  );
+}

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -22,10 +22,31 @@ export function getDatePart(date: Date = new Date()): Date {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0));
 }
 
+/**
+ * Returns the difference in days between two dates.
+ *
+ * @param startDate
+ * @param endDate
+ * @returns a number representing the days between the dates
+ */
 export function differenceInDays(startDate: Date, endDate: Date): number {
   const millisecondsPerDay = 86400000;
 
   return Math.round(
     (getDatePart(endDate).getTime() - getDatePart(startDate).getTime()) / millisecondsPerDay
   );
+}
+
+/**
+ * Formats the date in short form, eg. 2021-01-01
+ *
+ * @param date
+ * @returns A string representing the formatted date
+ */
+export function format(date: string | number | Date): string {
+  if (!(date instanceof Date)) {
+    date = new Date(date);
+  }
+
+  return getDatePart(date).toISOString().split('T')[0];
 }


### PR DESCRIPTION
In order to standardize how consumers interact with the dates we use in this package, we're introducing two new utils:

`differenceInDays`:

```ts
export function differenceInDays(startDate: Date, endDate: Date): number;
```

`format`

```ts
export function format(date: string | number | Date): string;
```

This will ensure that consumers who interact with our dates generate the correct values.