### PR TITLE
Renaming FilePath type to improve code readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Those utilities are:
 
 <dl>
 <dt><a href="#buildTodoData">buildTodoData(baseDir, lintResults, todoConfig)</a> ⇒</dt>
-<dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">FilePath</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
+<dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">TodoFileHash</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
 </dd>
 <dt><a href="#_buildTodoDatum">_buildTodoDatum(lintResult, lintMessage, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts an <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>. FilePaths are absolute
@@ -109,276 +109,299 @@ Config values can be present in</p>
 <a name="buildTodoData"></a>
 
 ## buildTodoData(baseDir, lintResults, todoConfig) ⇒
-Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a map of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35), [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-**Kind**: global function  
-**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a map of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35), [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
+**Kind**: global function
+**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
+
+| Param       | Description                                                                                                                                                                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| baseDir     | The base directory that contains the .lint-todo storage directory.                                                                                                                                                                                                                   |
 | lintResults | A list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) objects to convert to [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) objects. |
-| todoConfig | An object containing the warn or error days, in integers. |
+| todoConfig  | An object containing the warn or error days, in integers.                                                                                                                                                                                                                            |
 
 <a name="_buildTodoDatum"></a>
 
 ## \_buildTodoDatum(lintResult, lintMessage, todoConfig) ⇒
+
 Adapts an [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36). FilePaths are absolute
 when received from a lint result, so they're converted to relative paths for stability in
 serializing the contents to disc.
 
-**Kind**: global function  
-**Returns**: - A [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.  
+**Kind**: global function
+**Returns**: - A [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.
 
-| Param | Description |
-| --- | --- |
-| lintResult | The lint result object. |
+| Param       | Description                                                         |
+| ----------- | ------------------------------------------------------------------- |
+| lintResult  | The lint result object.                                             |
 | lintMessage | A lint message object representing a specific violation for a file. |
-| todoConfig | An object containing the warn or error days, in integers. |
+| todoConfig  | An object containing the warn or error days, in integers.           |
 
 <a name="todoStorageDirExists"></a>
 
 ## todoStorageDirExists(baseDir) ⇒
+
 Determines if the .lint-todo storage directory exists.
 
-**Kind**: global function  
-**Returns**: - true if the todo storage directory exists, otherwise false.  
+**Kind**: global function
+**Returns**: - true if the todo storage directory exists, otherwise false.
 
-| Param | Description |
-| --- | --- |
+| Param   | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="ensureTodoStorageDirSync"></a>
 
 ## ensureTodoStorageDirSync(baseDir) ⇒
+
 Creates, or ensures the creation of, the .lint-todo directory.
 
-**Kind**: global function  
-**Returns**: - The todo storage directory path.  
+**Kind**: global function
+**Returns**: - The todo storage directory path.
 
-| Param | Description |
-| --- | --- |
+| Param   | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="ensureTodoStorageDir"></a>
 
 ## ensureTodoStorageDir(baseDir) ⇒
+
 Creates, or ensures the creation of, the .lint-todo directory.
 
-**Kind**: global function  
-**Returns**: - A promise that resolves to the todo storage directory path.  
+**Kind**: global function
+**Returns**: - A promise that resolves to the todo storage directory path.
 
-| Param | Description |
-| --- | --- |
+| Param   | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="getTodoStorageDirPath"></a>
 
 ## getTodoStorageDirPath(baseDir) ⇒
-**Kind**: global function  
-**Returns**: - The todo storage directory path.  
 
-| Param | Description |
-| --- | --- |
+**Kind**: global function
+**Returns**: - The todo storage directory path.
+
+| Param   | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="todoFilePathFor"></a>
 
 ## todoFilePathFor(baseDir, todoData) ⇒
+
 Creates a file path from the linting data. Excludes extension.
 
-**Kind**: global function  
-**Returns**: - The todo file path for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.  
+**Kind**: global function
+**Returns**: - The todo file path for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.
 
-| Param | Description |
-| --- | --- |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
-| todoData | The linting data for an individual violation. |
+| Param    | Description                                                        |
+| -------- | ------------------------------------------------------------------ |
+| baseDir  | The base directory that contains the .lint-todo storage directory. |
+| todoData | The linting data for an individual violation.                      |
 
-**Example**  
+**Example**
+
 ```js
 42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839
 ```
+
 <a name="todoDirFor"></a>
 
 ## todoDirFor(filePath) ⇒
+
 Creates a short hash for the todo's file path.
 
-**Kind**: global function  
-**Returns**: - The todo directory for a specific filepath.  
+**Kind**: global function
+**Returns**: - The todo directory for a specific filepath.
 
-| Param | Description |
-| --- | --- |
+| Param    | Description                                                 |
+| -------- | ----------------------------------------------------------- |
 | filePath | The filePath from linting data for an individual violation. |
 
 <a name="todoFileNameFor"></a>
 
 ## todoFileNameFor(todoData) ⇒
+
 Generates a unique filename for a todo lint data.
 
-**Kind**: global function  
-**Returns**: - The todo file name for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.  
+**Kind**: global function
+**Returns**: - The todo file name for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.
 
-| Param | Description |
-| --- | --- |
+| Param    | Description                                   |
+| -------- | --------------------------------------------- |
 | todoData | The linting data for an individual violation. |
 
 <a name="writeTodosSync"></a>
 
 ## writeTodosSync(baseDir, lintResults, options) ⇒
+
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
 Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.
 
-**Kind**: global function  
-**Returns**: - The counts of added and removed todos.  
+**Kind**: global function
+**Returns**: - The counts of added and removed todos.
 
-| Param | Description |
-| --- | --- |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
-| lintResults | The raw linting data. |
-| options | An object containing write options. |
+| Param       | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| baseDir     | The base directory that contains the .lint-todo storage directory. |
+| lintResults | The raw linting data.                                              |
+| options     | An object containing write options.                                |
 
 <a name="writeTodos"></a>
 
 ## writeTodos(baseDir, lintResults, options) ⇒
+
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
 Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.
 
-**Kind**: global function  
-**Returns**: - A promise that resolves to the counts of added and removed todos.  
+**Kind**: global function
+**Returns**: - A promise that resolves to the counts of added and removed todos.
 
-| Param | Description |
-| --- | --- |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
-| lintResults | The raw linting data. |
-| options | An object containing write options. |
+| Param       | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| baseDir     | The base directory that contains the .lint-todo storage directory. |
+| lintResults | The raw linting data.                                              |
+| options     | An object containing write options.                                |
 
 <a name="readTodosSync"></a>
 
 ## readTodosSync(baseDir) ⇒
+
 Reads all todo files in the .lint-todo directory.
 
-**Kind**: global function  
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Kind**: global function
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
+| Param   | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="readTodos"></a>
 
 ## readTodos(baseDir) ⇒
+
 Reads all todo files in the .lint-todo directory.
 
-**Kind**: global function  
-**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Kind**: global function
+**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
+| Param   | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="readTodosForFilePathSync"></a>
 
 ## readTodosForFilePathSync(todoStorageDir, filePath) ⇒
+
 Reads todo files in the .lint-todo directory for a specific filePath.
 
-**Kind**: global function  
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Kind**: global function
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
-| todoStorageDir | The .lint-todo storage directory. |
-| filePath | The relative file path of the file to return todo items for. |
+| Param          | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| todoStorageDir | The .lint-todo storage directory.                            |
+| filePath       | The relative file path of the file to return todo items for. |
 
 <a name="readTodosForFilePath"></a>
 
 ## readTodosForFilePath(todoStorageDir, filePath) ⇒
+
 Reads todo files in the .lint-todo directory for a specific filePath.
 
-**Kind**: global function  
-**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Kind**: global function
+**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
-| todoStorageDir | The .lint-todo storage directory. |
-| filePath | The relative file path of the file to return todo items for. |
+| Param          | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| todoStorageDir | The .lint-todo storage directory.                            |
+| filePath       | The relative file path of the file to return todo items for. |
 
 <a name="getTodoBatchesSync"></a>
 
 ## getTodoBatchesSync(lintResults, existing) ⇒
+
 Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).
 
-**Kind**: global function  
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Kind**: global function
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
+| Param       | Description                          |
+| ----------- | ------------------------------------ |
 | lintResults | The linting data for all violations. |
-| existing | Existing todo lint data. |
+| existing    | Existing todo lint data.             |
 
 <a name="getTodoBatches"></a>
 
 ## getTodoBatches(lintResults, existing) ⇒
+
 Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).
 
-**Kind**: global function  
-**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [FilePath](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Kind**: global function
+**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-| Param | Description |
-| --- | --- |
+| Param       | Description                          |
+| ----------- | ------------------------------------ |
 | lintResults | The linting data for all violations. |
-| existing | Existing todo lint data. |
+| existing    | Existing todo lint data.             |
 
 <a name="applyTodoChangesSync"></a>
 
 ## applyTodoChangesSync(todoStorageDir, add, remove)
+
 Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
 
-**Kind**: global function  
+**Kind**: global function
 
-| Param | Description |
-| --- | --- |
+| Param          | Description                       |
+| -------------- | --------------------------------- |
 | todoStorageDir | The .lint-todo storage directory. |
-| add | Batch of todos to add. |
-| remove | Batch of todos to remove. |
+| add            | Batch of todos to add.            |
+| remove         | Batch of todos to remove.         |
 
 <a name="applyTodoChanges"></a>
 
 ## applyTodoChanges(todoStorageDir, add, remove)
+
 Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
 
-**Kind**: global function  
+**Kind**: global function
 
-| Param | Description |
-| --- | --- |
+| Param          | Description                       |
+| -------------- | --------------------------------- |
 | todoStorageDir | The .lint-todo storage directory. |
-| add | Batch of todos to add. |
-| remove | Batch of todos to remove. |
+| add            | Batch of todos to add.            |
+| remove         | Batch of todos to remove.         |
 
 <a name="getTodoConfig"></a>
 
 ## getTodoConfig(baseDir, engine, customDaysToDecay) ⇒
+
 Gets the todo configuration.
 Config values can be present in
 
 The package.json
 
-**Kind**: global function  
-**Returns**: - The todo config object.  
+**Kind**: global function
+**Returns**: - The todo config object.
 
-| Param | Description |
-| --- | --- |
-| baseDir | The base directory that contains the project's package.json. |
-| engine | The engine for this configuration, eg. eslint |
-| customDaysToDecay | The optional custom days to decay configuration. |
+| Param             | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| baseDir           | The base directory that contains the project's package.json. |
+| engine            | The engine for this configuration, eg. eslint                |
+| customDaysToDecay | The optional custom days to decay configuration.             |
 
-**Example**  
+**Example**
+
 ```json
 {
   "lintTodo": {
@@ -396,100 +419,104 @@ The package.json
 ```
 
 A .lint-todorc.js file
-**Example**  
+**Example**
+
 ```js
 module.exports = {
-  "some-engine": {
-    "daysToDecay": {
-      "warn": 5,
-      "error": 10
+  'some-engine': {
+    daysToDecay: {
+      warn: 5,
+      error: 10,
     },
-    "daysToDecayByRule": {
-      "no-bare-strings": { "warn": 10, "error": 20 }
-    }
-  }
-}
+    daysToDecayByRule: {
+      'no-bare-strings': { warn: 10, error: 20 },
+    },
+  },
+};
 ```
 
-Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`)
-	- Env vars override package.json config
+Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`) - Env vars override package.json config
 
-Passed in directly, such as from command line options.
-	- Passed in options override both env vars and package.json config
+Passed in directly, such as from command line options. - Passed in options override both env vars and package.json config
 <a name="validateConfig"></a>
 
 ## validateConfig(baseDir) ⇒
+
 Validates whether we have a unique config in a single location.
 
-**Kind**: global function  
-**Returns**: A ConfigValidationResult that indicates whether a config is unique  
+**Kind**: global function
+**Returns**: A ConfigValidationResult that indicates whether a config is unique
 
-| Param | Description |
-| --- | --- |
+| Param   | Description                                                  |
+| ------- | ------------------------------------------------------------ |
 | baseDir | The base directory that contains the project's package.json. |
 
 <a name="getSeverity"></a>
 
 ## getSeverity(todo, today) ⇒
+
 Returns the correct severity level based on the todo data's decay dates.
 
-**Kind**: global function  
-**Returns**: Severity - the lint severity based on the evaluation of the decay dates.  
+**Kind**: global function
+**Returns**: Severity - the lint severity based on the evaluation of the decay dates.
 
-| Param | Description |
-| --- | --- |
-| todo | The todo data. |
+| Param | Description                                              |
+| ----- | -------------------------------------------------------- |
+| todo  | The todo data.                                           |
 | today | A number representing a date (UNIX Epoch - milliseconds) |
 
 <a name="isExpired"></a>
 
 ## isExpired(date, today) ⇒
+
 Evaluates whether a date is expired (earlier than today)
 
-**Kind**: global function  
-**Returns**: true if the date is earlier than today, otherwise false  
+**Kind**: global function
+**Returns**: true if the date is earlier than today, otherwise false
 
-| Param | Description |
-| --- | --- |
-| date | The date to evaluate |
+| Param | Description                                              |
+| ----- | -------------------------------------------------------- |
+| date  | The date to evaluate                                     |
 | today | A number representing a date (UNIX Epoch - milliseconds) |
 
 <a name="getDatePart"></a>
 
 ## getDatePart(date) ⇒
+
 Converts a date to include year, month, and day values only (time is zeroed out).
 
-**Kind**: global function  
-**Returns**: Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'  
+**Kind**: global function
+**Returns**: Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
 
-| Param | Description |
-| --- | --- |
-| date | The date to convert |
+| Param | Description         |
+| ----- | ------------------- |
+| date  | The date to convert |
 
 <a name="differenceInDays"></a>
 
 ## differenceInDays(startDate, endDate) ⇒
+
 Returns the difference in days between two dates.
 
-**Kind**: global function  
-**Returns**: a number representing the days between the dates  
+**Kind**: global function
+**Returns**: a number representing the days between the dates
 
-| Param | Description |
-| --- | --- |
+| Param     | Description    |
+| --------- | -------------- |
 | startDate | The start date |
-| endDate | The end date |
+| endDate   | The end date   |
 
 <a name="format"></a>
 
 ## format(date) ⇒
+
 Formats the date in short form, eg. 2021-01-01
 
-**Kind**: global function  
-**Returns**: A string representing the formatted date  
+**Kind**: global function
+**Returns**: A string representing the formatted date
 
-| Param | Description |
-| --- | --- |
-| date | The date to format |
-
+| Param | Description        |
+| ----- | ------------------ |
+| date  | The date to format |
 
 <!--DOCS_END-->

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,22 +1,22 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
 import { todoFilePathFor } from './io';
-import { DaysToDecay, FilePath, LintMessage, LintResult, TodoConfig, TodoData } from './types';
+import { DaysToDecay, TodoFileHash, LintMessage, LintResult, TodoConfig, TodoData } from './types';
 import { getDatePart } from './date-utils';
 
 /**
- * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  *
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
  * @param lintResults - A list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} objects to convert to {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} objects.
  * @param todoConfig - An object containing the warn or error days, in integers.
- * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export function buildTodoData(
   baseDir: string,
   lintResults: LintResult[],
   todoConfig?: TodoConfig
-): Map<FilePath, TodoData> {
+): Map<TodoFileHash, TodoData> {
   const results = lintResults.filter((result) => result.messages.length > 0);
 
   const todoData = results.reduce((converted, lintResult) => {
@@ -29,7 +29,7 @@ export function buildTodoData(
     });
 
     return converted;
-  }, new Map<FilePath, TodoData>());
+  }, new Map<TodoFileHash, TodoData>());
 
   return todoData;
 }

--- a/src/io.ts
+++ b/src/io.ts
@@ -17,7 +17,7 @@ import {
   rmdir,
 } from 'fs-extra';
 import { buildTodoData } from './builders';
-import { FilePath, LintResult, TodoData, TodoBatchCounts, WriteTodoOptions } from './types';
+import { TodoFileHash, LintResult, TodoData, TodoBatchCounts, WriteTodoOptions } from './types';
 import { isExpired } from './date-utils';
 
 /**
@@ -122,7 +122,7 @@ export function writeTodosSync(
   options = Object.assign({ shouldRemove: () => true }, options ?? {});
 
   const todoStorageDir: string = ensureTodoStorageDirSync(baseDir);
-  const existing: Map<FilePath, TodoData> = options.filePath
+  const existing: Map<TodoFileHash, TodoData> = options.filePath
     ? readTodosForFilePathSync(baseDir, options.filePath)
     : readTodosSync(baseDir);
   // eslint-disable-next-line prefer-const
@@ -157,7 +157,7 @@ export async function writeTodos(
   options = Object.assign({ shouldRemove: () => true }, options ?? {});
 
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
-  const existing: Map<FilePath, TodoData> = options.filePath
+  const existing: Map<TodoFileHash, TodoData> = options.filePath
     ? await readTodosForFilePath(baseDir, options.filePath)
     : await readTodos(baseDir);
   // eslint-disable-next-line prefer-const
@@ -176,9 +176,9 @@ export async function writeTodos(
  * Reads all todo files in the .lint-todo directory.
  *
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
- * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
-export function readTodosSync(baseDir: string): Map<FilePath, TodoData> {
+export function readTodosSync(baseDir: string): Map<TodoFileHash, TodoData> {
   const map = new Map();
   const todoStorageDir: string = ensureTodoStorageDirSync(baseDir);
   const todoFileDirs = readdirSync(todoStorageDir);
@@ -199,9 +199,9 @@ export function readTodosSync(baseDir: string): Map<FilePath, TodoData> {
  * Reads all todo files in the .lint-todo directory.
  *
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
- * @returns - A Promise that resolves to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A Promise that resolves to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
-export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData>> {
+export async function readTodos(baseDir: string): Promise<Map<TodoFileHash, TodoData>> {
   const map = new Map();
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const todoFileDirs = await readdir(todoStorageDir);
@@ -223,12 +223,12 @@ export async function readTodos(baseDir: string): Promise<Map<FilePath, TodoData
  *
  * @param todoStorageDir - The .lint-todo storage directory.
  * @param filePath - The relative file path of the file to return todo items for.
- * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export function readTodosForFilePathSync(
   baseDir: string,
   filePath: string
-): Map<FilePath, TodoData> {
+): Map<TodoFileHash, TodoData> {
   const map = new Map();
   const todoStorageDir: string = ensureTodoStorageDirSync(baseDir);
   const todoFileDir = todoDirFor(filePath);
@@ -257,12 +257,12 @@ export function readTodosForFilePathSync(
  *
  * @param todoStorageDir - The .lint-todo storage directory.
  * @param filePath - The relative file path of the file to return todo items for.
- * @returns - A Promise that resolves to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A Promise that resolves to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export async function readTodosForFilePath(
   baseDir: string,
   filePath: string
-): Promise<Map<FilePath, TodoData>> {
+): Promise<Map<TodoFileHash, TodoData>> {
   const map = new Map();
   const todoStorageDir: string = await ensureTodoStorageDir(baseDir);
   const todoFileDir = todoDirFor(filePath);
@@ -291,17 +291,17 @@ export async function readTodosForFilePath(
  *
  * @param lintResults - The linting data for all violations.
  * @param existing - Existing todo lint data.
- * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export function getTodoBatchesSync(
-  lintResults: Map<FilePath, TodoData>,
-  existing: Map<FilePath, TodoData>,
+  lintResults: Map<TodoFileHash, TodoData>,
+  existing: Map<TodoFileHash, TodoData>,
   options: Partial<WriteTodoOptions>
-): Map<FilePath, TodoData>[] {
-  const add = new Map<FilePath, TodoData>();
-  const remove = new Map<FilePath, TodoData>();
-  const expired = new Map<FilePath, TodoData>();
-  const stable = new Map<FilePath, TodoData>();
+): Map<TodoFileHash, TodoData>[] {
+  const add = new Map<TodoFileHash, TodoData>();
+  const remove = new Map<TodoFileHash, TodoData>();
+  const expired = new Map<TodoFileHash, TodoData>();
+  const stable = new Map<TodoFileHash, TodoData>();
 
   for (const [fileHash, todoDatum] of lintResults) {
     if (!existing.has(fileHash)) {
@@ -336,17 +336,17 @@ export function getTodoBatchesSync(
  *
  * @param lintResults - The linting data for all violations.
  * @param existing - Existing todo lint data.
- * @returns - A Promise that resolves to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|FilePath}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A Promise that resolves to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export async function getTodoBatches(
-  lintResults: Map<FilePath, TodoData>,
-  existing: Map<FilePath, TodoData>,
+  lintResults: Map<TodoFileHash, TodoData>,
+  existing: Map<TodoFileHash, TodoData>,
   options: Partial<WriteTodoOptions>
-): Promise<Map<FilePath, TodoData>[]> {
-  const add = new Map<FilePath, TodoData>();
-  const remove = new Map<FilePath, TodoData>();
-  const expired = new Map<FilePath, TodoData>();
-  const stable = new Map<FilePath, TodoData>();
+): Promise<Map<TodoFileHash, TodoData>[]> {
+  const add = new Map<TodoFileHash, TodoData>();
+  const remove = new Map<TodoFileHash, TodoData>();
+  const expired = new Map<TodoFileHash, TodoData>();
+  const stable = new Map<TodoFileHash, TodoData>();
 
   for (const [fileHash, todoDatum] of lintResults) {
     if (!existing.has(fileHash)) {
@@ -385,8 +385,8 @@ export async function getTodoBatches(
  */
 export function applyTodoChangesSync(
   todoStorageDir: string,
-  add: Map<FilePath, TodoData>,
-  remove: Map<FilePath, TodoData>
+  add: Map<TodoFileHash, TodoData>,
+  remove: Map<TodoFileHash, TodoData>
 ): void {
   for (const [fileHash, todoDatum] of add) {
     const { dir } = posix.parse(fileHash);
@@ -416,8 +416,8 @@ export function applyTodoChangesSync(
  */
 export async function applyTodoChanges(
   todoStorageDir: string,
-  add: Map<FilePath, TodoData>,
-  remove: Map<FilePath, TodoData>
+  add: Map<TodoFileHash, TodoData>,
+  remove: Map<TodoFileHash, TodoData>
 ): Promise<void> {
   for (const [fileHash, todoDatum] of add) {
     const { dir } = posix.parse(fileHash);

--- a/src/io.ts
+++ b/src/io.ts
@@ -184,11 +184,11 @@ export function readTodosSync(baseDir: string): Map<TodoFileHash, TodoData> {
   const todoFileDirs = readdirSync(todoStorageDir);
 
   for (const todoFileDir of todoFileDirs) {
-    const fileNames = readdirSync(posix.join(todoStorageDir, todoFileDir));
+    const todoFileHashes = readdirSync(posix.join(todoStorageDir, todoFileDir));
 
-    for (const fileName of fileNames) {
-      const todo = readJSONSync(posix.join(todoStorageDir, todoFileDir, fileName));
-      map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
+    for (const todoFileHash of todoFileHashes) {
+      const todo = readJSONSync(posix.join(todoStorageDir, todoFileDir, todoFileHash));
+      map.set(posix.join(todoFileDir, posix.parse(todoFileHash).name), todo);
     }
   }
 
@@ -207,11 +207,11 @@ export async function readTodos(baseDir: string): Promise<Map<TodoFileHash, Todo
   const todoFileDirs = await readdir(todoStorageDir);
 
   for (const todoFileDir of todoFileDirs) {
-    const fileNames = await readdir(posix.join(todoStorageDir, todoFileDir));
+    const todoFileHashes = await readdir(posix.join(todoStorageDir, todoFileDir));
 
-    for (const fileName of fileNames) {
-      const todo = await readJSON(posix.join(todoStorageDir, todoFileDir, fileName));
-      map.set(posix.join(todoFileDir, posix.parse(fileName).name), todo);
+    for (const todoFileHash of todoFileHashes) {
+      const todo = await readJSON(posix.join(todoStorageDir, todoFileDir, todoFileHash));
+      map.set(posix.join(todoFileDir, posix.parse(todoFileHash).name), todo);
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,7 +32,7 @@ export interface TemplateLintMessage {
 export type LintResult = ESLint.LintResult | TemplateLintResult;
 export type LintMessage = Linter.LintMessage | TemplateLintMessage;
 
-export type FilePath = string;
+export type TodoFileHash = string;
 export interface TodoData {
   engine: 'eslint' | 'ember-template-lint';
   filePath: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,8 @@ export interface TemplateLintMessage {
 export type LintResult = ESLint.LintResult | TemplateLintResult;
 export type LintMessage = Linter.LintMessage | TemplateLintMessage;
 
+// This type is deprecated, but is still included here for backwards compatibility.
+export type FilePath = string;
 export type TodoFileHash = string;
 export interface TodoData {
   engine: 'eslint' | 'ember-template-lint';


### PR DESCRIPTION
The current `FilePath` type didn't do a good job at hinting at what this type represented, which isn't exactly a file path, but rather a generated hash for the Todo file path on disc. This update makes it easier to understand the relationship in the Map data structure used throughout the codebase, where the key is the `TodoFileHash`, and the value is the `TodoData`. 

Note: This is part of a number of refactors to transform the code to use fuzzy matching.