### PR TITLE
Adding expanded todo batching functionality to account for fuzzy matching

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,13 +2,14 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "jest", "prettier", "tsdoc"],
   "extends": [
-    "prettier",
+    "eslint:recommended",
     "prettier/@typescript-eslint",
     "plugin:@typescript-eslint/recommended",
     "plugin:jest/recommended",
     "plugin:jest/style",
     "plugin:node/recommended",
-    "plugin:unicorn/recommended"
+    "plugin:unicorn/recommended",
+    "prettier"
   ],
   "parserOptions": {
     "ecmaVersion": 2018,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Those utilities are:
 <dt><a href="#buildTodoData">buildTodoData(baseDir, lintResults, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">TodoFileHash</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
 </dd>
+<dt><a href="#buildTodoData2">buildTodoData2(baseDir, lintResults, todoConfig)</a> ⇒</dt>
+<dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">TodoFileHash</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
+</dd>
 <dt><a href="#_buildTodoDatum">_buildTodoDatum(lintResult, lintMessage, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts an <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>. FilePaths are absolute
 when received from a lint result, so they&#39;re converted to relative paths for stability in
@@ -27,9 +30,6 @@ serializing the contents to disc.</p>
 </dd>
 <dt><a href="#todoStorageDirExists">todoStorageDirExists(baseDir)</a> ⇒</dt>
 <dd><p>Determines if the .lint-todo storage directory exists.</p>
-</dd>
-<dt><a href="#ensureTodoStorageDirSync">ensureTodoStorageDirSync(baseDir)</a> ⇒</dt>
-<dd><p>Creates, or ensures the creation of, the .lint-todo directory.</p>
 </dd>
 <dt><a href="#ensureTodoStorageDir">ensureTodoStorageDir(baseDir)</a> ⇒</dt>
 <dd><p>Creates, or ensures the creation of, the .lint-todo directory.</p>
@@ -45,38 +45,20 @@ serializing the contents to disc.</p>
 <dt><a href="#todoFileNameFor">todoFileNameFor(todoData)</a> ⇒</dt>
 <dd><p>Generates a unique filename for a todo lint data.</p>
 </dd>
-<dt><a href="#writeTodosSync">writeTodosSync(baseDir, lintResults, options)</a> ⇒</dt>
-<dd><p>Writes files for todo lint violations. One file is generated for each violation, using a generated
-hash to identify each.</p>
-<p>Given a list of todo lint violations, this function will also delete existing files that no longer
-have a todo lint violation.</p>
-</dd>
 <dt><a href="#writeTodos">writeTodos(baseDir, lintResults, options)</a> ⇒</dt>
 <dd><p>Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.</p>
 <p>Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.</p>
 </dd>
-<dt><a href="#readTodosSync">readTodosSync(baseDir)</a> ⇒</dt>
-<dd><p>Reads all todo files in the .lint-todo directory.</p>
-</dd>
 <dt><a href="#readTodos">readTodos(baseDir)</a> ⇒</dt>
 <dd><p>Reads all todo files in the .lint-todo directory.</p>
-</dd>
-<dt><a href="#readTodosForFilePathSync">readTodosForFilePathSync(todoStorageDir, filePath)</a> ⇒</dt>
-<dd><p>Reads todo files in the .lint-todo directory for a specific filePath.</p>
 </dd>
 <dt><a href="#readTodosForFilePath">readTodosForFilePath(todoStorageDir, filePath)</a> ⇒</dt>
 <dd><p>Reads todo files in the .lint-todo directory for a specific filePath.</p>
 </dd>
 <dt><a href="#getTodoBatchesSync">getTodoBatchesSync(lintResults, existing)</a> ⇒</dt>
 <dd><p>Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).</p>
-</dd>
-<dt><a href="#getTodoBatches">getTodoBatches(lintResults, existing)</a> ⇒</dt>
-<dd><p>Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).</p>
-</dd>
-<dt><a href="#applyTodoChangesSync">applyTodoChangesSync(todoStorageDir, add, remove)</a></dt>
-<dd><p>Applies todo changes, either adding or removing, based on batches from <code>getTodoBatches</code>.</p>
 </dd>
 <dt><a href="#applyTodoChanges">applyTodoChanges(todoStorageDir, add, remove)</a></dt>
 <dd><p>Applies todo changes, either adding or removing, based on batches from <code>getTodoBatches</code>.</p>
@@ -109,299 +91,209 @@ Config values can be present in</p>
 <a name="buildTodoData"></a>
 
 ## buildTodoData(baseDir, lintResults, todoConfig) ⇒
-
 Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a map of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35), [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
-**Kind**: global function
-**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
+**Kind**: global function  
+**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
 
-| Param       | Description                                                                                                                                                                                                                                                                          |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| baseDir     | The base directory that contains the .lint-todo storage directory.                                                                                                                                                                                                                   |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage directory. |
 | lintResults | A list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) objects to convert to [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) objects. |
-| todoConfig  | An object containing the warn or error days, in integers.                                                                                                                                                                                                                            |
+| todoConfig | An object containing the warn or error days, in integers. |
+
+<a name="buildTodoData2"></a>
+
+## buildTodoData2(baseDir, lintResults, todoConfig) ⇒
+Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a map of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35), [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
+
+**Kind**: global function  
+**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage directory. |
+| lintResults | A list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) objects to convert to [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) objects. |
+| todoConfig | An object containing the warn or error days, in integers. |
 
 <a name="_buildTodoDatum"></a>
 
 ## \_buildTodoDatum(lintResult, lintMessage, todoConfig) ⇒
-
 Adapts an [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36). FilePaths are absolute
 when received from a lint result, so they're converted to relative paths for stability in
 serializing the contents to disc.
 
-**Kind**: global function
-**Returns**: - A [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.
+**Kind**: global function  
+**Returns**: - A [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.  
 
-| Param       | Description                                                         |
-| ----------- | ------------------------------------------------------------------- |
-| lintResult  | The lint result object.                                             |
+| Param | Description |
+| --- | --- |
+| lintResult | The lint result object. |
 | lintMessage | A lint message object representing a specific violation for a file. |
-| todoConfig  | An object containing the warn or error days, in integers.           |
+| todoConfig | An object containing the warn or error days, in integers. |
 
 <a name="todoStorageDirExists"></a>
 
 ## todoStorageDirExists(baseDir) ⇒
-
 Determines if the .lint-todo storage directory exists.
 
-**Kind**: global function
-**Returns**: - true if the todo storage directory exists, otherwise false.
+**Kind**: global function  
+**Returns**: - true if the todo storage directory exists, otherwise false.  
 
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
-
-<a name="ensureTodoStorageDirSync"></a>
-
-## ensureTodoStorageDirSync(baseDir) ⇒
-
-Creates, or ensures the creation of, the .lint-todo directory.
-
-**Kind**: global function
-**Returns**: - The todo storage directory path.
-
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="ensureTodoStorageDir"></a>
 
 ## ensureTodoStorageDir(baseDir) ⇒
-
 Creates, or ensures the creation of, the .lint-todo directory.
 
-**Kind**: global function
-**Returns**: - A promise that resolves to the todo storage directory path.
+**Kind**: global function  
+**Returns**: - The todo storage directory path.  
 
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="getTodoStorageDirPath"></a>
 
 ## getTodoStorageDirPath(baseDir) ⇒
+**Kind**: global function  
+**Returns**: - The todo storage directory path.  
 
-**Kind**: global function
-**Returns**: - The todo storage directory path.
-
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
 
 <a name="todoFilePathFor"></a>
 
 ## todoFilePathFor(baseDir, todoData) ⇒
-
 Creates a file path from the linting data. Excludes extension.
 
-**Kind**: global function
-**Returns**: - The todo file path for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.
+**Kind**: global function  
+**Returns**: - The todo file path for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.  
 
-| Param    | Description                                                        |
-| -------- | ------------------------------------------------------------------ |
-| baseDir  | The base directory that contains the .lint-todo storage directory. |
-| todoData | The linting data for an individual violation.                      |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the .lint-todo storage directory. |
+| todoData | The linting data for an individual violation. |
 
-**Example**
-
+**Example**  
 ```js
 42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839
 ```
-
 <a name="todoDirFor"></a>
 
 ## todoDirFor(filePath) ⇒
-
 Creates a short hash for the todo's file path.
 
-**Kind**: global function
-**Returns**: - The todo directory for a specific filepath.
+**Kind**: global function  
+**Returns**: - The todo directory for a specific filepath.  
 
-| Param    | Description                                                 |
-| -------- | ----------------------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | filePath | The filePath from linting data for an individual violation. |
 
 <a name="todoFileNameFor"></a>
 
 ## todoFileNameFor(todoData) ⇒
-
 Generates a unique filename for a todo lint data.
 
-**Kind**: global function
-**Returns**: - The todo file name for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.
+**Kind**: global function  
+**Returns**: - The todo file name for a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) object.  
 
-| Param    | Description                                   |
-| -------- | --------------------------------------------- |
+| Param | Description |
+| --- | --- |
 | todoData | The linting data for an individual violation. |
-
-<a name="writeTodosSync"></a>
-
-## writeTodosSync(baseDir, lintResults, options) ⇒
-
-Writes files for todo lint violations. One file is generated for each violation, using a generated
-hash to identify each.
-
-Given a list of todo lint violations, this function will also delete existing files that no longer
-have a todo lint violation.
-
-**Kind**: global function
-**Returns**: - The counts of added and removed todos.
-
-| Param       | Description                                                        |
-| ----------- | ------------------------------------------------------------------ |
-| baseDir     | The base directory that contains the .lint-todo storage directory. |
-| lintResults | The raw linting data.                                              |
-| options     | An object containing write options.                                |
 
 <a name="writeTodos"></a>
 
 ## writeTodos(baseDir, lintResults, options) ⇒
-
 Writes files for todo lint violations. One file is generated for each violation, using a generated
 hash to identify each.
 
 Given a list of todo lint violations, this function will also delete existing files that no longer
 have a todo lint violation.
 
-**Kind**: global function
-**Returns**: - A promise that resolves to the counts of added and removed todos.
+**Kind**: global function  
+**Returns**: - The counts of added and removed todos.  
 
-| Param       | Description                                                        |
-| ----------- | ------------------------------------------------------------------ |
-| baseDir     | The base directory that contains the .lint-todo storage directory. |
-| lintResults | The raw linting data.                                              |
-| options     | An object containing write options.                                |
-
-<a name="readTodosSync"></a>
-
-## readTodosSync(baseDir) ⇒
-
-Reads all todo files in the .lint-todo directory.
-
-**Kind**: global function
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
-
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
+| lintResults | The raw linting data. |
+| options | An object containing write options. |
 
 <a name="readTodos"></a>
 
 ## readTodos(baseDir) ⇒
-
 Reads all todo files in the .lint-todo directory.
 
-**Kind**: global function
-**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
+**Kind**: global function  
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFilePathHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L51)/[TodoMatcher](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/todo-matcher.ts#L4).  
 
-| Param   | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the .lint-todo storage directory. |
-
-<a name="readTodosForFilePathSync"></a>
-
-## readTodosForFilePathSync(todoStorageDir, filePath) ⇒
-
-Reads todo files in the .lint-todo directory for a specific filePath.
-
-**Kind**: global function
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
-
-| Param          | Description                                                  |
-| -------------- | ------------------------------------------------------------ |
-| todoStorageDir | The .lint-todo storage directory.                            |
-| filePath       | The relative file path of the file to return todo items for. |
 
 <a name="readTodosForFilePath"></a>
 
 ## readTodosForFilePath(todoStorageDir, filePath) ⇒
-
 Reads todo files in the .lint-todo directory for a specific filePath.
 
-**Kind**: global function
-**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
+**Kind**: global function  
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFilePathHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L51)/[TodoMatcher](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/todo-matcher.ts#L4).  
 
-| Param          | Description                                                  |
-| -------------- | ------------------------------------------------------------ |
-| todoStorageDir | The .lint-todo storage directory.                            |
-| filePath       | The relative file path of the file to return todo items for. |
+| Param | Description |
+| --- | --- |
+| todoStorageDir | The .lint-todo storage directory. |
+| filePath | The relative file path of the file to return todo items for. |
 
 <a name="getTodoBatchesSync"></a>
 
 ## getTodoBatchesSync(lintResults, existing) ⇒
-
 Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).
 
-**Kind**: global function
-**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
+**Kind**: global function  
+**Returns**: - A [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
 
-| Param       | Description                          |
-| ----------- | ------------------------------------ |
+| Param | Description |
+| --- | --- |
 | lintResults | The linting data for all violations. |
-| existing    | Existing todo lint data.             |
-
-<a name="getTodoBatches"></a>
-
-## getTodoBatches(lintResults, existing) ⇒
-
-Gets 3 maps containing todo items to add, remove, or those that are stable (not to be modified).
-
-**Kind**: global function
-**Returns**: - A Promise that resolves to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
-
-| Param       | Description                          |
-| ----------- | ------------------------------------ |
-| lintResults | The linting data for all violations. |
-| existing    | Existing todo lint data.             |
-
-<a name="applyTodoChangesSync"></a>
-
-## applyTodoChangesSync(todoStorageDir, add, remove)
-
-Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
-
-**Kind**: global function
-
-| Param          | Description                       |
-| -------------- | --------------------------------- |
-| todoStorageDir | The .lint-todo storage directory. |
-| add            | Batch of todos to add.            |
-| remove         | Batch of todos to remove.         |
+| existing | Existing todo lint data. |
 
 <a name="applyTodoChanges"></a>
 
 ## applyTodoChanges(todoStorageDir, add, remove)
-
 Applies todo changes, either adding or removing, based on batches from `getTodoBatches`.
 
-**Kind**: global function
+**Kind**: global function  
 
-| Param          | Description                       |
-| -------------- | --------------------------------- |
+| Param | Description |
+| --- | --- |
 | todoStorageDir | The .lint-todo storage directory. |
-| add            | Batch of todos to add.            |
-| remove         | Batch of todos to remove.         |
+| add | Batch of todos to add. |
+| remove | Batch of todos to remove. |
 
 <a name="getTodoConfig"></a>
 
 ## getTodoConfig(baseDir, engine, customDaysToDecay) ⇒
-
 Gets the todo configuration.
 Config values can be present in
 
 The package.json
 
-**Kind**: global function
-**Returns**: - The todo config object.
+**Kind**: global function  
+**Returns**: - The todo config object.  
 
-| Param             | Description                                                  |
-| ----------------- | ------------------------------------------------------------ |
-| baseDir           | The base directory that contains the project's package.json. |
-| engine            | The engine for this configuration, eg. eslint                |
-| customDaysToDecay | The optional custom days to decay configuration.             |
+| Param | Description |
+| --- | --- |
+| baseDir | The base directory that contains the project's package.json. |
+| engine | The engine for this configuration, eg. eslint |
+| customDaysToDecay | The optional custom days to decay configuration. |
 
-**Example**
-
+**Example**  
 ```json
 {
   "lintTodo": {
@@ -419,104 +311,100 @@ The package.json
 ```
 
 A .lint-todorc.js file
-**Example**
-
+**Example**  
 ```js
 module.exports = {
-  'some-engine': {
-    daysToDecay: {
-      warn: 5,
-      error: 10,
+  "some-engine": {
+    "daysToDecay": {
+      "warn": 5,
+      "error": 10
     },
-    daysToDecayByRule: {
-      'no-bare-strings': { warn: 10, error: 20 },
-    },
-  },
-};
+    "daysToDecayByRule": {
+      "no-bare-strings": { "warn": 10, "error": 20 }
+    }
+  }
+}
 ```
 
-Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`) - Env vars override package.json config
+Environment variables (`TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR`)
+	- Env vars override package.json config
 
-Passed in directly, such as from command line options. - Passed in options override both env vars and package.json config
+Passed in directly, such as from command line options.
+	- Passed in options override both env vars and package.json config
 <a name="validateConfig"></a>
 
 ## validateConfig(baseDir) ⇒
-
 Validates whether we have a unique config in a single location.
 
-**Kind**: global function
-**Returns**: A ConfigValidationResult that indicates whether a config is unique
+**Kind**: global function  
+**Returns**: A ConfigValidationResult that indicates whether a config is unique  
 
-| Param   | Description                                                  |
-| ------- | ------------------------------------------------------------ |
+| Param | Description |
+| --- | --- |
 | baseDir | The base directory that contains the project's package.json. |
 
 <a name="getSeverity"></a>
 
 ## getSeverity(todo, today) ⇒
-
 Returns the correct severity level based on the todo data's decay dates.
 
-**Kind**: global function
-**Returns**: Severity - the lint severity based on the evaluation of the decay dates.
+**Kind**: global function  
+**Returns**: Severity - the lint severity based on the evaluation of the decay dates.  
 
-| Param | Description                                              |
-| ----- | -------------------------------------------------------- |
-| todo  | The todo data.                                           |
+| Param | Description |
+| --- | --- |
+| todo | The todo data. |
 | today | A number representing a date (UNIX Epoch - milliseconds) |
 
 <a name="isExpired"></a>
 
 ## isExpired(date, today) ⇒
-
 Evaluates whether a date is expired (earlier than today)
 
-**Kind**: global function
-**Returns**: true if the date is earlier than today, otherwise false
+**Kind**: global function  
+**Returns**: true if the date is earlier than today, otherwise false  
 
-| Param | Description                                              |
-| ----- | -------------------------------------------------------- |
-| date  | The date to evaluate                                     |
+| Param | Description |
+| --- | --- |
+| date | The date to evaluate |
 | today | A number representing a date (UNIX Epoch - milliseconds) |
 
 <a name="getDatePart"></a>
 
 ## getDatePart(date) ⇒
-
 Converts a date to include year, month, and day values only (time is zeroed out).
 
-**Kind**: global function
-**Returns**: Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'
+**Kind**: global function  
+**Returns**: Date - A date with the time zeroed out eg. '2021-01-01T08:00:00.000Z'  
 
-| Param | Description         |
-| ----- | ------------------- |
-| date  | The date to convert |
+| Param | Description |
+| --- | --- |
+| date | The date to convert |
 
 <a name="differenceInDays"></a>
 
 ## differenceInDays(startDate, endDate) ⇒
-
 Returns the difference in days between two dates.
 
-**Kind**: global function
-**Returns**: a number representing the days between the dates
+**Kind**: global function  
+**Returns**: a number representing the days between the dates  
 
-| Param     | Description    |
-| --------- | -------------- |
+| Param | Description |
+| --- | --- |
 | startDate | The start date |
-| endDate   | The end date   |
+| endDate | The end date |
 
 <a name="format"></a>
 
 ## format(date) ⇒
-
 Formats the date in short form, eg. 2021-01-01
 
-**Kind**: global function
-**Returns**: A string representing the formatted date
+**Kind**: global function  
+**Returns**: A string representing the formatted date  
 
-| Param | Description        |
-| ----- | ------------------ |
-| date  | The date to format |
+| Param | Description |
+| --- | --- |
+| date | The date to format |
+
 
 <!--DOCS_END-->

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Those utilities are:
 <dt><a href="#buildTodoData">buildTodoData(baseDir, lintResults, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">TodoFileHash</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
 </dd>
-<dt><a href="#_buildTodoDatum">_buildTodoDatum(lintResult, lintMessage, todoConfig)</a> ⇒</dt>
+<dt><a href="#buildTodoDatum">buildTodoDatum(lintResult, lintMessage, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts an <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>. FilePaths are absolute
 when received from a lint result, so they&#39;re converted to relative paths for stability in
 serializing the contents to disc.</p>
@@ -99,9 +99,9 @@ Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-templ
 | lintResults | A list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) objects to convert to [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) objects. |
 | todoConfig | An object containing the warn or error days, in integers. |
 
-<a name="_buildTodoDatum"></a>
+<a name="buildTodoDatum"></a>
 
-## \_buildTodoDatum(lintResult, lintMessage, todoConfig) ⇒
+## buildTodoDatum(lintResult, lintMessage, todoConfig) ⇒
 Adapts an [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36). FilePaths are absolute
 when received from a lint result, so they're converted to relative paths for stability in
 serializing the contents to disc.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ Those utilities are:
 <dt><a href="#buildTodoData">buildTodoData(baseDir, lintResults, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">TodoFileHash</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
 </dd>
-<dt><a href="#buildTodoData2">buildTodoData2(baseDir, lintResults, todoConfig)</a> ⇒</dt>
-<dd><p>Adapts a list of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a map of <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35">TodoFileHash</a>, <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>.</p>
-</dd>
 <dt><a href="#_buildTodoDatum">_buildTodoDatum(lintResult, lintMessage, todoConfig)</a> ⇒</dt>
 <dd><p>Adapts an <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32">LintResult</a> to a <a href="https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36">TodoData</a>. FilePaths are absolute
 when received from a lint result, so they&#39;re converted to relative paths for stability in
@@ -94,21 +91,7 @@ Config values can be present in</p>
 Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a map of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35), [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
 
 **Kind**: global function  
-**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
-
-| Param | Description |
-| --- | --- |
-| baseDir | The base directory that contains the .lint-todo storage directory. |
-| lintResults | A list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) objects to convert to [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36) objects. |
-| todoConfig | An object containing the warn or error days, in integers. |
-
-<a name="buildTodoData2"></a>
-
-## buildTodoData2(baseDir, lintResults, todoConfig) ⇒
-Adapts a list of [LintResult](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32) to a map of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35), [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).
-
-**Kind**: global function  
-**Returns**: - A Promise resolving to a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of [TodoFileHash](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35)/[TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
+**Returns**: - A Promise resolving to a [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) of [TodoData](https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36).  
 
 | Param | Description |
 | --- | --- |

--- a/__tests__/__utils__/build-todo-data.ts
+++ b/__tests__/__utils__/build-todo-data.ts
@@ -1,4 +1,4 @@
-import { _buildTodoDatum } from '../../src/builders';
+import { buildTodoDatum } from '../../src/builders';
 import { todoDirFor } from '../../src/io';
 import TodoMatcher from '../../src/todo-matcher';
 import { LintMessage, LintResult, TodoConfig, TodoFilePathHash } from '../../src/types';
@@ -13,7 +13,7 @@ export function buildTodoDataForTesting(
   const todoData = results.reduce((converted, lintResult) => {
     lintResult.messages.forEach((message: LintMessage) => {
       if (message.severity === 2) {
-        const todoDatum = _buildTodoDatum(baseDir, lintResult, message, todoConfig);
+        const todoDatum = buildTodoDatum(baseDir, lintResult, message, todoConfig);
         const todoFilePathHash = todoDirFor(todoDatum.filePath);
 
         if (!converted.has(todoFilePathHash)) {

--- a/__tests__/__utils__/build-todo-data.ts
+++ b/__tests__/__utils__/build-todo-data.ts
@@ -1,0 +1,33 @@
+import { _buildTodoDatum } from '../../src/builders';
+import { todoDirFor } from '../../src/io';
+import TodoMatcher from '../../src/todo-matcher';
+import { LintMessage, LintResult, TodoConfig, TodoFilePathHash } from '../../src/types';
+
+export function buildTodoDataForTesting(
+  baseDir: string,
+  lintResults: LintResult[],
+  todoConfig?: TodoConfig
+): Map<TodoFilePathHash, TodoMatcher> {
+  const results = lintResults.filter((result) => result.messages.length > 0);
+
+  const todoData = results.reduce((converted, lintResult) => {
+    lintResult.messages.forEach((message: LintMessage) => {
+      if (message.severity === 2) {
+        const todoDatum = _buildTodoDatum(baseDir, lintResult, message, todoConfig);
+        const todoFilePathHash = todoDirFor(todoDatum.filePath);
+
+        if (!converted.has(todoFilePathHash)) {
+          converted.set(todoFilePathHash, new TodoMatcher());
+        }
+
+        const matcher = converted.get(todoFilePathHash);
+
+        matcher?.add(todoDatum);
+      }
+    });
+
+    return converted;
+  }, new Map<TodoFilePathHash, TodoMatcher>());
+
+  return todoData;
+}

--- a/__tests__/__utils__/get-fixture.ts
+++ b/__tests__/__utils__/get-fixture.ts
@@ -4,10 +4,11 @@ import { updatePaths } from './update-path';
 import { ESLint } from 'eslint';
 import { TemplateLintResult } from '../../src/types';
 
-export function getFixture<T extends ESLint.LintResult | TemplateLintResult>(fileName: string, tmp: string): T[] {
-  const fixture = readJsonSync(
-    resolve(join('./__tests__/__fixtures__/', `${fileName}.json`))
-  );
+export function getFixture<T extends ESLint.LintResult | TemplateLintResult>(
+  fileName: string,
+  tmp: string
+): T[] {
+  const fixture = readJsonSync(resolve(join('./__tests__/__fixtures__/', `${fileName}.json`)));
 
-  return updatePaths(tmp, fixture.hasOwnProperty('results') ? fixture.results : fixture);
+  return updatePaths(tmp, 'results' in fixture ? fixture.results : fixture);
 }

--- a/__tests__/builders-test.ts
+++ b/__tests__/builders-test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ESLint, Linter } from 'eslint';
 import { differenceInDays } from 'date-fns';
-import { _buildTodoDatum, buildTodoData, getDatePart } from '../src';
+import { buildTodoDatum, buildTodoData, getDatePart } from '../src';
 import { TemplateLintMessage, TemplateLintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
 import { updatePath } from './__utils__/update-path';
@@ -51,7 +51,7 @@ describe('builders', () => {
         endColumn: 35,
       };
 
-      const todoDatum = _buildTodoDatum(tmp, eslintResult, eslintMessage);
+      const todoDatum = buildTodoDatum(tmp, eslintResult, eslintMessage);
 
       expect(todoDatum).toEqual(
         expect.objectContaining({
@@ -156,7 +156,7 @@ describe('builders', () => {
         source: '',
       };
 
-      const todoDatum = _buildTodoDatum(tmp, emberTemplateLintResult, emberTemplateLintMessage);
+      const todoDatum = buildTodoDatum(tmp, emberTemplateLintResult, emberTemplateLintMessage);
 
       expect(todoDatum).toEqual(
         expect.objectContaining({

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -1,20 +1,14 @@
-import { existsSync, readdir, statSync, readJson } from 'fs-extra';
+import { existsSync, readdir, readdirSync, statSync } from 'fs-extra';
 import { posix } from 'path';
 import { subDays } from 'date-fns';
 import {
   buildTodoData,
   ensureTodoStorageDir,
-  ensureTodoStorageDirSync,
-  getTodoBatches,
-  getTodoBatchesSync,
   todoDirFor,
   todoFileNameFor,
   todoFilePathFor,
   todoStorageDirExists,
   writeTodos,
-  writeTodosSync,
-  readTodosSync,
-  readTodos,
   getDatePart,
   getTodoStorageDirPath,
 } from '../src';
@@ -22,6 +16,9 @@ import { LintResult, TodoData } from '../src/types';
 import { createTmpDir } from './__utils__/tmp-dir';
 import { updatePaths } from './__utils__';
 import { getFixture } from './__utils__/get-fixture';
+import { getTodoBatchesSync } from '../src/io';
+import TodoMatcher from '../src/todo-matcher';
+import { buildTodoDataForTesting } from './__utils__/build-todo-data';
 
 const TODO_DATA: TodoData = {
   engine: 'eslint',
@@ -32,12 +29,12 @@ const TODO_DATA: TodoData = {
   createdDate: getDatePart(new Date('12/11/2020')).getTime(),
 };
 
-async function readFiles(todoStorageDir: string) {
+function readFiles(todoStorageDir: string) {
   const fileNames: string[] = [];
-  const todoFileDirs = await readdir(todoStorageDir);
+  const todoFileDirs = readdirSync(todoStorageDir);
 
   for (const todoFileDir of todoFileDirs) {
-    const files = (await readdir(posix.join(todoStorageDir, todoFileDir))).map((file) =>
+    const files = readdirSync(posix.join(todoStorageDir, todoFileDir)).map((file) =>
       posix.join(todoFileDir, file)
     );
 
@@ -46,6 +43,8 @@ async function readFiles(todoStorageDir: string) {
 
   return fileNames;
 }
+
+jest.setTimeout(100000);
 
 describe('io', () => {
   let tmp: string;
@@ -60,13 +59,7 @@ describe('io', () => {
     });
 
     it('returns true when directory exists sync', async () => {
-      ensureTodoStorageDirSync(tmp);
-
-      expect(todoStorageDirExists(tmp)).toEqual(true);
-    });
-
-    it('returns true when directory exists', async () => {
-      await ensureTodoStorageDir(tmp);
+      ensureTodoStorageDir(tmp);
 
       expect(todoStorageDirExists(tmp)).toEqual(true);
     });
@@ -118,235 +111,29 @@ describe('io', () => {
     });
   });
 
-  describe('writeTodosSync', () => {
-    it("creates .lint-todo directory if one doesn't exist", async () => {
-      const todoDir = getTodoStorageDirPath(tmp);
-
-      writeTodosSync(tmp, []);
-
-      expect(existsSync(todoDir)).toEqual(true);
-    });
-
-    it("doesn't write files when no todos provided", async () => {
-      writeTodosSync(tmp, []);
-
-      expect(readTodosSync(tmp).size).toEqual(0);
-    });
-
-    it('generates todos when todos provided', async () => {
-      const [added] = writeTodosSync(tmp, getFixture('eslint-with-errors', tmp));
-
-      expect(added).toEqual(18);
-      expect(readTodosSync(tmp).size).toEqual(18);
-    });
-
-    it("generates todos only if previous todo doesn't exist", async () => {
-      const initialTodos: LintResult[] = [
-        {
-          filePath: '{{path}}/app/controllers/settings.js',
-          messages: [
-            {
-              ruleId: 'no-prototype-builtins',
-              severity: 2,
-              message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-              line: 25,
-              column: 21,
-              nodeType: 'CallExpression',
-              messageId: 'prototypeBuildIn',
-              endLine: 25,
-              endColumn: 35,
-            },
-            {
-              ruleId: 'no-prototype-builtins',
-              severity: 2,
-              message: "Do not access Object.prototype method 'hasOwnProperty' from target object.",
-              line: 26,
-              column: 19,
-              nodeType: 'CallExpression',
-              messageId: 'prototypeBuildIn',
-              endLine: 26,
-              endColumn: 33,
-            },
-          ],
-          errorCount: 2,
-          warningCount: 0,
-          fixableErrorCount: 0,
-          fixableWarningCount: 0,
-          source: '',
-          usedDeprecatedRules: [],
-        },
-      ];
-
-      const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(tmp, updatePaths<LintResult>(tmp, initialTodos));
-      const initialFiles = await readFiles(todoDir);
-
-      expect(added).toEqual(2);
-      expect(initialFiles).toHaveLength(2);
-
-      const initialFileStats = initialFiles.map((file) => {
-        return {
-          fileName: file,
-          ctime: statSync(posix.join(todoDir, file)).ctime,
-        };
-      });
-
-      writeTodosSync(tmp, getFixture('eslint-with-errors', tmp));
-
-      const subsequentFiles = await readFiles(todoDir);
-
-      expect(subsequentFiles).toHaveLength(18);
-
-      initialFileStats.forEach((initialFileStat) => {
-        const subsequentFile = statSync(posix.join(todoDir, initialFileStat.fileName));
-
-        expect(subsequentFile.ctime).toEqual(initialFileStat.ctime);
-      });
-    });
-
-    it('removes old todos if todos no longer contains violations', async () => {
-      const fixture = getFixture('eslint-with-errors', tmp);
-      const todoDir = getTodoStorageDirPath(tmp);
-
-      const [added] = writeTodosSync(tmp, fixture);
-
-      const initialFiles = await readFiles(todoDir);
-
-      expect(added).toEqual(18);
-      expect(initialFiles).toHaveLength(18);
-
-      const firstHalf = fixture.slice(0, 3);
-      const secondHalf = fixture.slice(3, fixture.length);
-
-      const [, removed] = writeTodosSync(tmp, firstHalf);
-
-      const subsequentFiles = await readFiles(todoDir);
-
-      expect(removed).toEqual(11);
-      expect(subsequentFiles).toHaveLength(7);
-
-      buildTodoData(tmp, secondHalf).forEach((todoDatum) => {
-        expect(!existsSync(posix.join(todoDir, `${todoFilePathFor(todoDatum)}.json`))).toEqual(
-          true
-        );
-      });
-    });
-
-    it('does not remove old todos if todos no longer contains violations if shouldRemove returns false', async () => {
-      const fixture = getFixture('eslint-with-errors', tmp);
-      const todoDir = getTodoStorageDirPath(tmp);
-
-      const [added] = writeTodosSync(tmp, fixture);
-
-      const initialFiles = await readFiles(todoDir);
-
-      expect(added).toEqual(18);
-      expect(initialFiles).toHaveLength(18);
-
-      const firstHalf = fixture.slice(0, 3);
-
-      const [, removed] = writeTodosSync(tmp, firstHalf, { shouldRemove: () => false });
-
-      const subsequentFiles = await readFiles(todoDir);
-
-      expect(removed).toEqual(0);
-      expect(subsequentFiles).toHaveLength(18);
-    });
-  });
-
-  describe('writeTodosSync for single file', () => {
-    it('generates todos for a specific filePath', async () => {
-      const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(tmp, getFixture('single-file-todo', tmp), {
-        filePath: 'app/controllers/settings.js',
-      });
-
-      expect(added).toEqual(3);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
-        ]
-      `);
-    });
-
-    it('updates todos for a specific filePath', async () => {
-      const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(tmp, getFixture('single-file-todo', tmp), {
-        filePath: 'app/controllers/settings.js',
-      });
-
-      expect(added).toEqual(3);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
-        ]
-      `);
-
-      const [added2, removed2] = writeTodosSync(tmp, getFixture('single-file-todo-updated', tmp), {
-        filePath: 'app/controllers/settings.js',
-      });
-
-      expect(added2).toEqual(1);
-      expect(removed2).toEqual(1);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/ee492fc4.json",
-        ]
-      `);
-    });
-
-    it('deletes todos for a specific filePath', async () => {
-      const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = writeTodosSync(tmp, getFixture('single-file-todo', tmp), {
-        filePath: 'app/controllers/settings.js',
-      });
-
-      expect(added).toEqual(3);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
-        ]
-      `);
-
-      const [added2, removed2] = writeTodosSync(tmp, getFixture('single-file-no-errors', tmp), {
-        filePath: 'app/controllers/settings.js',
-      });
-
-      expect(added2).toEqual(0);
-      expect(removed2).toEqual(3);
-      expect(await readFiles(todoDir)).toHaveLength(0);
-      expect(await readdir(todoDir)).toHaveLength(0);
-    });
-  });
-
   describe('writeTodos', () => {
     it("creates .lint-todo directory if one doesn't exist", async () => {
       const todoDir = getTodoStorageDirPath(tmp);
 
-      await writeTodos(tmp, []);
+      writeTodos(tmp, []);
 
       expect(existsSync(todoDir)).toEqual(true);
     });
 
     it("doesn't write files when no todos provided", async () => {
-      await writeTodos(tmp, []);
+      const todoDir = getTodoStorageDirPath(tmp);
 
-      expect((await readTodos(tmp)).size).toEqual(0);
+      writeTodos(tmp, []);
+
+      expect(readFiles(todoDir)).toHaveLength(0);
     });
 
     it('generates todos when todos provided', async () => {
-      const [added] = await writeTodos(tmp, getFixture('eslint-with-errors', tmp));
+      const todoDir = getTodoStorageDirPath(tmp);
+      const [added] = writeTodos(tmp, getFixture('eslint-with-errors', tmp));
 
       expect(added).toEqual(18);
-      expect((await readTodos(tmp)).size).toEqual(18);
+      expect(readFiles(todoDir)).toHaveLength(18);
     });
 
     it("generates todos only if previous todo doesn't exist", async () => {
@@ -385,10 +172,10 @@ describe('io', () => {
           usedDeprecatedRules: [],
         },
       ];
-
+      debugger;
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(tmp, updatePaths<LintResult>(tmp, initialTodos));
-      const initialFiles = await readFiles(todoDir);
+      const [added] = writeTodos(tmp, updatePaths<LintResult>(tmp, initialTodos));
+      const initialFiles = readFiles(todoDir);
 
       expect(added).toEqual(2);
       expect(initialFiles).toHaveLength(2);
@@ -400,9 +187,9 @@ describe('io', () => {
         };
       });
 
-      await writeTodos(tmp, getFixture('eslint-with-errors', tmp));
+      writeTodos(tmp, getFixture('eslint-with-errors', tmp));
 
-      const subsequentFiles = await readFiles(todoDir);
+      const subsequentFiles = readFiles(todoDir);
 
       expect(subsequentFiles).toHaveLength(18);
 
@@ -417,9 +204,9 @@ describe('io', () => {
       const fixture = getFixture('eslint-with-errors', tmp);
       const todoDir = getTodoStorageDirPath(tmp);
 
-      const [added] = await writeTodos(tmp, fixture);
+      const [added] = writeTodos(tmp, fixture);
 
-      const initialFiles = await readFiles(todoDir);
+      const initialFiles = readFiles(todoDir);
 
       expect(added).toEqual(18);
       expect(initialFiles).toHaveLength(18);
@@ -427,9 +214,9 @@ describe('io', () => {
       const firstHalf = fixture.slice(0, 3);
       const secondHalf = fixture.slice(3, fixture.length);
 
-      const [, removed] = await writeTodos(tmp, firstHalf);
+      const [, removed] = writeTodos(tmp, firstHalf);
 
-      const subsequentFiles = await readFiles(todoDir);
+      const subsequentFiles = readFiles(todoDir);
 
       expect(removed).toEqual(11);
       expect(subsequentFiles).toHaveLength(7);
@@ -441,66 +228,23 @@ describe('io', () => {
       });
     });
 
-    it('does not remove todos owned by different engine', async () => {
-      const todoDir = getTodoStorageDirPath(tmp);
-
-      await writeTodos(tmp, getFixture('ember-template-lint-single-error', tmp));
-
-      const fixture = getFixture('eslint-single-error', tmp);
-
-      const [added] = await writeTodos(tmp, fixture, {
-        shouldRemove: (todoDatum) => todoDatum.engine === 'eslint',
-      });
-
-      const initialFiles = await readFiles(todoDir);
-
-      expect(added).toEqual(1);
-      expect(initialFiles).toHaveLength(2);
-
-      const [, removed] = await writeTodos(tmp, getFixture('eslint-single-error2', tmp), {
-        shouldRemove: (todoDatum) => todoDatum.engine === 'eslint',
-      });
-
-      const subsequentFiles = await readFiles(todoDir);
-
-      expect(removed).toEqual(1);
-      expect(subsequentFiles).toHaveLength(2);
-      expect(await readJson(posix.join(todoDir, subsequentFiles[0]))).toEqual(
-        expect.objectContaining({
-          column: 11,
-          engine: 'eslint',
-          filePath: 'app/initializers/tracer.js',
-          line: 1,
-          ruleId: 'no-redeclare',
-        })
-      );
-      expect(await readJson(posix.join(todoDir, subsequentFiles[1]))).toEqual(
-        expect.objectContaining({
-          column: 4,
-          engine: 'ember-template-lint',
-          filePath: 'app/templates/components/add-ssh-key.hbs',
-          line: 3,
-          ruleId: 'require-input-label',
-        })
-      );
-    });
-
     it('does not remove old todos if todos no longer contains violations if shouldRemove returns false', async () => {
+      debugger;
       const fixture = getFixture('eslint-with-errors', tmp);
       const todoDir = getTodoStorageDirPath(tmp);
 
-      const [added] = await writeTodos(tmp, fixture);
+      const [added] = writeTodos(tmp, fixture);
 
-      const initialFiles = await readFiles(todoDir);
+      const initialFiles = readFiles(todoDir);
 
       expect(added).toEqual(18);
       expect(initialFiles).toHaveLength(18);
 
       const firstHalf = fixture.slice(0, 3);
 
-      const [, removed] = await writeTodos(tmp, firstHalf, { shouldRemove: () => false });
+      const [, removed] = writeTodos(tmp, firstHalf, { shouldRemove: () => false });
 
-      const subsequentFiles = await readFiles(todoDir);
+      const subsequentFiles = readFiles(todoDir);
 
       expect(removed).toEqual(0);
       expect(subsequentFiles).toHaveLength(18);
@@ -510,12 +254,12 @@ describe('io', () => {
   describe('writeTodos for single file', () => {
     it('generates todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(tmp, getFixture('single-file-todo', tmp), {
+      const [added] = writeTodos(tmp, getFixture('single-file-todo', tmp), {
         filePath: 'app/controllers/settings.js',
       });
 
       expect(added).toEqual(3);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+      expect(readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
@@ -525,13 +269,14 @@ describe('io', () => {
     });
 
     it('updates todos for a specific filePath', async () => {
+      debugger;
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(tmp, getFixture('single-file-todo', tmp), {
+      const [added] = writeTodos(tmp, getFixture('single-file-todo', tmp), {
         filePath: 'app/controllers/settings.js',
       });
 
       expect(added).toEqual(3);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+      expect(readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
@@ -539,17 +284,12 @@ describe('io', () => {
         ]
       `);
 
-      const [added2, removed2] = await writeTodos(
-        tmp,
-        getFixture('single-file-todo-updated', tmp),
-        {
-          filePath: 'app/controllers/settings.js',
-        }
-      );
+      const counts = writeTodos(tmp, getFixture('single-file-todo-updated', tmp), {
+        filePath: 'app/controllers/settings.js',
+      });
 
-      expect(added2).toEqual(1);
-      expect(removed2).toEqual(1);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+      expect(counts).toStrictEqual([1, 1, 2, 0]);
+      expect(readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25.json",
@@ -560,12 +300,12 @@ describe('io', () => {
 
     it('deletes todos for a specific filePath', async () => {
       const todoDir = getTodoStorageDirPath(tmp);
-      const [added] = await writeTodos(tmp, getFixture('single-file-todo', tmp), {
+      const [added] = writeTodos(tmp, getFixture('single-file-todo', tmp), {
         filePath: 'app/controllers/settings.js',
       });
 
       expect(added).toEqual(3);
-      expect(await readFiles(todoDir)).toMatchInlineSnapshot(`
+      expect(readFiles(todoDir)).toMatchInlineSnapshot(`
         Array [
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0.json",
           "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839.json",
@@ -573,24 +313,22 @@ describe('io', () => {
         ]
       `);
 
-      const [added2, removed2] = await writeTodos(tmp, getFixture('single-file-no-errors', tmp), {
+      const [added2, removed2] = writeTodos(tmp, getFixture('single-file-no-errors', tmp), {
         filePath: 'app/controllers/settings.js',
       });
 
       expect(added2).toEqual(0);
       expect(removed2).toEqual(3);
-      expect(await readFiles(todoDir)).toHaveLength(0);
+      expect(readFiles(todoDir)).toHaveLength(0);
       expect(await readdir(todoDir)).toHaveLength(0);
     });
   });
 
   describe('getTodoBatchesSync', () => {
     it('creates items to add', async () => {
-      const [add] = getTodoBatchesSync(
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
-        new Map(),
-        { shouldRemove: () => true }
-      );
+      const { add } = getTodoBatchesSync(tmp, getFixture('new-batches', tmp), new Map(), {
+        shouldRemove: () => true,
+      });
 
       expect([...add.keys()]).toMatchInlineSnapshot(`
         Array [
@@ -605,9 +343,10 @@ describe('io', () => {
     });
 
     it('creates items to delete', async () => {
-      const [, remove] = getTodoBatchesSync(
-        new Map(),
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
+      const { remove } = getTodoBatchesSync(
+        tmp,
+        [],
+        buildTodoDataForTesting(tmp, getFixture('new-batches', tmp)),
         { shouldRemove: () => true }
       );
 
@@ -624,23 +363,21 @@ describe('io', () => {
     });
 
     it('creates items to expire', async () => {
-      const expiredBatches: Map<string, TodoData> = buildTodoData(
+      const expiredBatches: Map<string, TodoMatcher> = buildTodoDataForTesting(
         tmp,
         getFixture('new-batches', tmp)
       );
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const expiredTodo: TodoData = expiredBatches.get(
-        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
-      )!;
+      const expiredTodo: TodoData = expiredBatches
+        .get('60a67ad5c653f5b1a6537d9a6aee56c0662c0e35')!
+        .find('cc71e5f9')!;
 
       expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
 
       // eslint-disable-next-line unicorn/no-unreadable-array-destructuring
-      const [, , , expired] = getTodoBatchesSync(
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
-        expiredBatches,
-        { shouldRemove: () => true }
-      );
+      const { expired } = getTodoBatchesSync(tmp, getFixture('new-batches', tmp), expiredBatches, {
+        shouldRemove: () => true,
+      });
 
       expect([...expired.keys()]).toMatchInlineSnapshot(`
         Array [
@@ -650,123 +387,20 @@ describe('io', () => {
     });
 
     it('creates all batches', async () => {
-      const existingBatches = buildTodoData(tmp, getFixture('existing-batches', tmp));
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const expiredTodo: TodoData = existingBatches.get(
-        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
-      )!;
-
-      expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
-
-      const [add, remove, stable, expired] = getTodoBatchesSync(
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
-        existingBatches,
-        { shouldRemove: () => true }
-      );
-
-      expect([...add.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
-        ]
-      `);
-      expect([...remove.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "07d3818b8afefcdd7db6d52743309fdbb85313f0/66256fb7",
-          "07d3818b8afefcdd7db6d52743309fdbb85313f0/8fd35486",
-        ]
-      `);
-      expect([...stable.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
-        ]
-      `);
-      expect([...expired.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
-        ]
-      `);
-    });
-  });
-
-  describe('getTodoBatches', () => {
-    it('creates items to add', async () => {
-      const [add] = await getTodoBatches(
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
-        new Map(),
-        { shouldRemove: () => true }
-      );
-
-      expect([...add.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
-        ]
-      `);
-    });
-
-    it('creates items to delete', async () => {
-      const [, remove] = await getTodoBatches(
-        new Map(),
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
-        { shouldRemove: () => true }
-      );
-
-      expect([...remove.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
-          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
-        ]
-      `);
-    });
-
-    it('creates items to expire', async () => {
-      const expiredBatches: Map<string, TodoData> = buildTodoData(
+      const existingBatches: Map<string, TodoMatcher> = buildTodoDataForTesting(
         tmp,
-        getFixture('new-batches', tmp)
+        getFixture('existing-batches', tmp)
       );
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const expiredTodo: TodoData = expiredBatches.get(
-        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
-      )!;
+      const expiredTodo: TodoData = existingBatches
+        .get('60a67ad5c653f5b1a6537d9a6aee56c0662c0e35')!
+        .find('cc71e5f9')!;
 
       expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
 
-      // eslint-disable-next-line unicorn/no-unreadable-array-destructuring
-      const [, , , expired] = await getTodoBatches(
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
-        expiredBatches,
-        { shouldRemove: () => true }
-      );
-
-      expect([...expired.keys()]).toMatchInlineSnapshot(`
-        Array [
-          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
-        ]
-      `);
-    });
-
-    it('creates all batches', async () => {
-      const existingBatches = buildTodoData(tmp, getFixture('existing-batches', tmp));
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const expiredTodo: TodoData = existingBatches.get(
-        '60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9'
-      )!;
-
-      expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
-
-      const [add, remove, stable, expired] = await getTodoBatches(
-        buildTodoData(tmp, getFixture('new-batches', tmp)),
+      const { add, remove, stable, expired } = getTodoBatchesSync(
+        tmp,
+        getFixture('new-batches', tmp),
         existingBatches,
         { shouldRemove: () => true }
       );

--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -172,7 +172,7 @@ describe('io', () => {
           usedDeprecatedRules: [],
         },
       ];
-      debugger;
+
       const todoDir = getTodoStorageDirPath(tmp);
       const [added] = writeTodos(tmp, updatePaths<LintResult>(tmp, initialTodos));
       const initialFiles = readFiles(todoDir);
@@ -229,7 +229,6 @@ describe('io', () => {
     });
 
     it('does not remove old todos if todos no longer contains violations if shouldRemove returns false', async () => {
-      debugger;
       const fixture = getFixture('eslint-with-errors', tmp);
       const todoDir = getTodoStorageDirPath(tmp);
 
@@ -269,7 +268,6 @@ describe('io', () => {
     });
 
     it('updates todos for a specific filePath', async () => {
-      debugger;
       const todoDir = getTodoStorageDirPath(tmp);
       const [added] = writeTodos(tmp, getFixture('single-file-todo', tmp), {
         filePath: 'app/controllers/settings.js',

--- a/__tests__/todo-batch-generator-test.ts
+++ b/__tests__/todo-batch-generator-test.ts
@@ -1,0 +1,130 @@
+import { subDays } from 'date-fns';
+import { getDatePart } from '../src/date-utils';
+import TodoBatchGenerator from '../src/todo-batch-generator';
+import TodoMatcher from '../src/todo-matcher';
+import { TodoData, TodoFilePathHash } from '../src/types';
+import { buildTodoDataForTesting } from './__utils__/build-todo-data';
+import { getFixture } from './__utils__/get-fixture';
+import { createTmpDir } from './__utils__/tmp-dir';
+
+describe('todo-batch-generator', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = createTmpDir();
+  });
+
+  it('generates no batches when lint results are empty', () => {
+    const todoBatchGenerator = new TodoBatchGenerator(tmp);
+
+    expect(todoBatchGenerator.generate([], new Map())).toMatchInlineSnapshot(`
+      Object {
+        "add": Map {},
+        "expired": Map {},
+        "remove": Set {},
+        "stable": Map {},
+      }
+    `);
+  });
+
+  it('creates items to add', async () => {
+    const todoBatchGenerator = new TodoBatchGenerator(tmp, { shouldRemove: () => true });
+    const { add } = todoBatchGenerator.generate(getFixture('new-batches', tmp), new Map());
+
+    expect([...add.keys()]).toMatchInlineSnapshot(`
+      Array [
+        "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+        "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+        "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+        "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+        "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+        "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+      ]
+    `);
+  });
+
+  it('creates items to remove', async () => {
+    const todoBatchGenerator = new TodoBatchGenerator(tmp, { shouldRemove: () => true });
+    const { remove } = todoBatchGenerator.generate(
+      [],
+      buildTodoDataForTesting(tmp, getFixture('new-batches', tmp))
+    );
+
+    expect([...remove]).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+        ]
+      `);
+  });
+
+  it('creates items to expire', async () => {
+    const expiredBatches: Map<TodoFilePathHash, TodoMatcher> = buildTodoDataForTesting(
+      tmp,
+      getFixture('new-batches', tmp)
+    );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const expiredTodo: TodoData = expiredBatches
+      .get('60a67ad5c653f5b1a6537d9a6aee56c0662c0e35')!
+      .find('cc71e5f9')!;
+
+    expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
+
+    const todoBatchGenerator = new TodoBatchGenerator(tmp, { shouldRemove: () => true });
+    const { expired } = todoBatchGenerator.generate(getFixture('new-batches', tmp), expiredBatches);
+
+    expect([...expired.keys()]).toMatchInlineSnapshot(`
+      Array [
+        "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+      ]
+    `);
+  });
+
+  it('creates all batches', async () => {
+    const existingBatches: Map<TodoFilePathHash, TodoMatcher> = buildTodoDataForTesting(
+      tmp,
+      getFixture('existing-batches', tmp)
+    );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const expiredTodo: TodoData = existingBatches
+      .get('60a67ad5c653f5b1a6537d9a6aee56c0662c0e35')!
+      .find('cc71e5f9')!;
+
+    expiredTodo.errorDate = subDays(getDatePart(), 1).getTime();
+
+    const todoBatchGenerator = new TodoBatchGenerator(tmp, { shouldRemove: () => true });
+    const { add, remove, stable, expired } = todoBatchGenerator.generate(
+      getFixture('new-batches', tmp),
+      existingBatches
+    );
+
+    expect([...add.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/6e3be839",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/aad8bc25",
+          "0a1e71cf4d0931e81f494d5a73a550016814e15a/53e7a9a0",
+        ]
+      `);
+    expect([...remove.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "07d3818b8afefcdd7db6d52743309fdbb85313f0/66256fb7",
+          "07d3818b8afefcdd7db6d52743309fdbb85313f0/8fd35486",
+        ]
+      `);
+    expect([...stable.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/b9046d34",
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/092271fa",
+        ]
+      `);
+    expect([...expired.keys()]).toMatchInlineSnapshot(`
+        Array [
+          "60a67ad5c653f5b1a6537d9a6aee56c0662c0e35/cc71e5f9",
+        ]
+      `);
+  });
+});

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,7 +1,6 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
-import { todoFilePathFor } from './io';
-import { DaysToDecay, TodoFileHash, LintMessage, LintResult, TodoConfig, TodoData } from './types';
+import { DaysToDecay, LintMessage, LintResult, TodoConfig, TodoData } from './types';
 import { getDatePart } from './date-utils';
 
 /**
@@ -13,36 +12,6 @@ import { getDatePart } from './date-utils';
  * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export function buildTodoData(
-  baseDir: string,
-  lintResults: LintResult[],
-  todoConfig?: TodoConfig
-): Map<TodoFileHash, TodoData> {
-  const results = lintResults.filter((result) => result.messages.length > 0);
-
-  const todoData = results.reduce((converted, lintResult) => {
-    lintResult.messages.forEach((message: LintMessage) => {
-      if (message.severity === 2) {
-        const todoDatum = _buildTodoDatum(baseDir, lintResult, message, todoConfig);
-
-        converted.set(todoFilePathFor(todoDatum), todoDatum);
-      }
-    });
-
-    return converted;
-  }, new Map<TodoFileHash, TodoData>());
-
-  return todoData;
-}
-
-/**
- * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
- *
- * @param baseDir - The base directory that contains the .lint-todo storage directory.
- * @param lintResults - A list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} objects to convert to {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} objects.
- * @param todoConfig - An object containing the warn or error days, in integers.
- * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
- */
-export function buildTodoData2(
   baseDir: string,
   lintResults: LintResult[],
   todoConfig?: TodoConfig

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,17 +1,8 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
-import { todoDirFor, todoFilePathFor } from './io';
-import {
-  DaysToDecay,
-  TodoFileHash,
-  LintMessage,
-  LintResult,
-  TodoConfig,
-  TodoData,
-  TodoFilePathHash,
-} from './types';
+import { todoFilePathFor } from './io';
+import { DaysToDecay, TodoFileHash, LintMessage, LintResult, TodoConfig, TodoData } from './types';
 import { getDatePart } from './date-utils';
-import TodoMatcher from './todo-matcher';
 
 /**
  * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,8 +1,17 @@
 import { isAbsolute, relative } from 'path';
 import slash = require('slash');
-import { todoFilePathFor } from './io';
-import { DaysToDecay, TodoFileHash, LintMessage, LintResult, TodoConfig, TodoData } from './types';
+import { todoDirFor, todoFilePathFor } from './io';
+import {
+  DaysToDecay,
+  TodoFileHash,
+  LintMessage,
+  LintResult,
+  TodoConfig,
+  TodoData,
+  TodoFilePathHash,
+} from './types';
 import { getDatePart } from './date-utils';
+import TodoMatcher from './todo-matcher';
 
 /**
  * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
@@ -30,6 +39,36 @@ export function buildTodoData(
 
     return converted;
   }, new Map<TodoFileHash, TodoData>());
+
+  return todoData;
+}
+
+/**
+ * Adapts a list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} to a map of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}, {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ *
+ * @param baseDir - The base directory that contains the .lint-todo storage directory.
+ * @param lintResults - A list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} objects to convert to {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} objects.
+ * @param todoConfig - An object containing the warn or error days, in integers.
+ * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ */
+export function buildTodoData2(
+  baseDir: string,
+  lintResults: LintResult[],
+  todoConfig?: TodoConfig
+): Set<TodoData> {
+  const results = lintResults.filter((result) => result.messages.length > 0);
+
+  const todoData = results.reduce((converted, lintResult) => {
+    lintResult.messages.forEach((message: LintMessage) => {
+      if (message.severity === 2) {
+        const todoDatum = _buildTodoDatum(baseDir, lintResult, message, todoConfig);
+
+        converted.add(todoDatum);
+      }
+    });
+
+    return converted;
+  }, new Set<TodoData>());
 
   return todoData;
 }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -21,7 +21,7 @@ export function buildTodoData(
   const todoData = results.reduce((converted, lintResult) => {
     lintResult.messages.forEach((message: LintMessage) => {
       if (message.severity === 2) {
-        const todoDatum = _buildTodoDatum(baseDir, lintResult, message, todoConfig);
+        const todoDatum = buildTodoDatum(baseDir, lintResult, message, todoConfig);
 
         converted.add(todoDatum);
       }
@@ -43,7 +43,7 @@ export function buildTodoData(
  * @param todoConfig - An object containing the warn or error days, in integers.
  * @returns - A {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} object.
  */
-export function _buildTodoDatum(
+export function buildTodoDatum(
   baseDir: string,
   lintResult: LintResult,
   lintMessage: LintMessage,

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -9,7 +9,7 @@ import { getDatePart } from './date-utils';
  * @param baseDir - The base directory that contains the .lint-todo storage directory.
  * @param lintResults - A list of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L32|LintResult} objects to convert to {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} objects.
  * @param todoConfig - An object containing the warn or error days, in integers.
- * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map|Map} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L35|TodoFileHash}/{@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
+ * @returns - A Promise resolving to a {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set|Set} of {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData}.
  */
 export function buildTodoData(
   baseDir: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,16 @@ export {
   applyTodoChanges,
   ensureTodoStorageDir,
   getTodoStorageDirPath,
-  getTodoBatches,
+  readTodos,
+  readTodosForFilePath,
   todoStorageDirExists,
   todoDirFor,
   todoFileNameFor,
   todoFilePathFor,
-  readTodos,
-  readTodosForFilePath,
   writeTodos,
-  applyTodoChangesSync,
-  ensureTodoStorageDirSync,
-  getTodoBatchesSync,
-  readTodosSync,
-  readTodosForFilePathSync,
-  writeTodosSync,
 } from './io';
 export { getTodoConfig, validateConfig } from './todo-config';
 export { getSeverity } from './get-severity';
-export { getDatePart, isExpired, differenceInDays, format } from './date-utils';
+export { differenceInDays, format, getDatePart, isExpired } from './date-utils';
 
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { _buildTodoDatum, buildTodoData } from './builders';
+export { buildTodoDatum, buildTodoData } from './builders';
 export {
   applyTodoChanges,
   ensureTodoStorageDir,

--- a/src/todo-batch-generator.ts
+++ b/src/todo-batch-generator.ts
@@ -1,0 +1,128 @@
+import { buildTodoData2 } from './builders';
+import { isExpired } from './date-utils';
+import { todoDirFor, todoFilePathFor } from './io';
+import TodoMatcher from './todo-matcher';
+import {
+  LintResult,
+  TodoBatches,
+  TodoData,
+  TodoFileHash,
+  TodoFilePathHash,
+  WriteTodoOptions,
+} from './types';
+
+/**
+ * Creates todo batches based on lint results.
+ */
+export default class TodoBatchGenerator {
+  /**
+   * Create a TodoBatchGenerator
+   *
+   * @param baseDir - The base directory that contains the .lint-todo storage directory.
+   * @param options - An object containing write options.
+   */
+  constructor(private baseDir: string, private options?: Partial<WriteTodoOptions>) {}
+
+  /**
+   * Matches todos to their associated {@link https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/src/types/index.ts#L36|TodoData} object.
+   *
+   * The matching algorithm uses the following logic:
+   *
+   * For each unmatched lint result
+   *   Find associated TodoMatcher by filePath
+   *   Try to exact match against any of the TodoMatcher's Todos
+   *
+   *   if is exact match
+   *     if expired && shouldRemove then add to "expired"
+   *     else then add to "stable"
+   *     remove from unmatched for either case above
+   *
+   * For each remaining unmatched lint result
+   *   Find associated TodoMatcher by filePath
+   *   Try to fuzzy match against any of the TodoMatcher's Todos
+   *
+   *   if is fuzzy match
+   *     if expired && shouldRemove then add to "expired"
+   *     else then add to "stable"
+   *     remove from unmatched for either case above
+   *   else
+   *     then add to "add"
+   *
+   * For each remaining existing todos
+   *   if shouldRemove then add to "remove
+   *
+   * Exact matches match on engine, ruleID, line and column
+   * Fuzzy matches match on engine, ruleID and source
+   *
+   * @param lintResults - The raw linting data.
+   * @param existingTodos - Existing todo lint data.
+   * @returns
+   */
+  generate(
+    lintResults: LintResult[],
+    existingTodos: Map<TodoFilePathHash, TodoMatcher>
+  ): TodoBatches {
+    const add = new Map<TodoFileHash, TodoData>();
+    const expired = new Map<TodoFileHash, TodoData>();
+    const stable = new Map<TodoFileHash, TodoData>();
+    let remove = new Set<TodoFileHash>();
+
+    const unmatched = buildTodoData2(this.baseDir, lintResults, this.options?.todoConfig);
+
+    for (const unmatchedTodoData of unmatched) {
+      const todoFilePathHash = todoDirFor(unmatchedTodoData.filePath);
+      const matcher = existingTodos.get(todoFilePathHash);
+
+      if (matcher) {
+        const todoDatum = matcher.exactMatch(unmatchedTodoData);
+
+        if (todoDatum) {
+          const todoFilePath = todoFilePathFor(todoDatum);
+          if (isExpired(todoDatum.errorDate) && this.options?.shouldRemove?.(todoDatum)) {
+            expired.set(todoFilePath, todoDatum);
+          } else {
+            stable.set(todoFilePath, todoDatum);
+          }
+
+          unmatched.delete(unmatchedTodoData);
+        }
+      }
+    }
+
+    for (const unmatchedTodoData of unmatched) {
+      const todoFilePathHash = todoDirFor(unmatchedTodoData.filePath);
+      const matcher = existingTodos.get(todoFilePathHash);
+
+      if (matcher) {
+        const todoDatum = matcher.fuzzyMatch(unmatchedTodoData);
+
+        if (todoDatum) {
+          const todoFilePath = todoFilePathFor(todoDatum);
+
+          if (isExpired(todoDatum.errorDate) && this.options?.shouldRemove?.(todoDatum)) {
+            expired.set(todoFilePath, todoDatum);
+          } else {
+            stable.set(todoFilePath, todoDatum);
+          }
+        } else {
+          add.set(todoFilePathFor(unmatchedTodoData), unmatchedTodoData);
+        }
+      } else {
+        add.set(todoFilePathFor(unmatchedTodoData), unmatchedTodoData);
+      }
+
+      unmatched.delete(unmatchedTodoData);
+    }
+
+    for (const matcher of [...existingTodos.values()]) {
+      remove = new Set([...remove, ...matcher.unmatched(this.options?.shouldRemove)]);
+    }
+
+    return {
+      add,
+      expired,
+      stable,
+      remove,
+    };
+  }
+}

--- a/src/todo-batch-generator.ts
+++ b/src/todo-batch-generator.ts
@@ -1,4 +1,4 @@
-import { buildTodoData2 } from './builders';
+import { buildTodoData } from './builders';
 import { isExpired } from './date-utils';
 import { todoDirFor, todoFilePathFor } from './io';
 import TodoMatcher from './todo-matcher';
@@ -67,7 +67,7 @@ export default class TodoBatchGenerator {
     const stable = new Map<TodoFileHash, TodoData>();
     let remove = new Set<TodoFileHash>();
 
-    const unmatched = buildTodoData2(this.baseDir, lintResults, this.options?.todoConfig);
+    const unmatched = buildTodoData(this.baseDir, lintResults, this.options?.todoConfig);
 
     for (const unmatchedTodoData of unmatched) {
       const todoFilePathHash = todoDirFor(unmatchedTodoData.filePath);

--- a/src/todo-matcher.ts
+++ b/src/todo-matcher.ts
@@ -1,0 +1,67 @@
+import { todoFilePathFor, todoFileNameFor } from './io';
+import { TodoData, TodoFilePathHash } from './types';
+
+export default class TodoMatcher {
+  private unprocessed: Set<TodoData>;
+
+  constructor() {
+    this.unprocessed = new Set();
+  }
+
+  unmatched(predicate: (todoDatum: TodoData) => boolean = () => false): string[] {
+    return [...this.unprocessed]
+      .filter((todoDatum) => predicate(todoDatum))
+      .map((todoDatum: TodoData) => {
+        return todoFilePathFor(todoDatum);
+      });
+  }
+
+  add(todoDatum: TodoData): void {
+    this.unprocessed.add(todoDatum);
+  }
+
+  find(todoFilePathHash: TodoFilePathHash): TodoData | undefined {
+    return [...this.unprocessed].find(
+      (todoDatum) => todoFileNameFor(todoDatum) === todoFilePathHash
+    );
+  }
+
+  exactMatch(todoDataToFind: TodoData): TodoData | undefined {
+    let found;
+
+    for (const todoDatum of this.unprocessed) {
+      if (
+        todoDataToFind.engine === todoDatum.engine &&
+        todoDataToFind.ruleId === todoDatum.ruleId &&
+        todoDataToFind.line === todoDatum.line &&
+        todoDataToFind.column === todoDatum.column
+      ) {
+        found = todoDatum;
+        this.unprocessed.delete(todoDatum);
+        break;
+      }
+    }
+
+    return found;
+  }
+
+  fuzzyMatch(todoDataToFind: TodoData): TodoData | undefined {
+    let found;
+
+    for (const todoDatum of this.unprocessed) {
+      if (
+        todoDataToFind.engine === todoDatum.engine &&
+        todoDataToFind.ruleId === todoDatum.ruleId &&
+        todoDataToFind.source !== undefined &&
+        todoDatum.source !== undefined &&
+        todoDataToFind.source === todoDatum.source
+      ) {
+        found = todoDatum;
+        this.unprocessed.delete(todoDatum);
+        break;
+      }
+    }
+
+    return found;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,14 +33,44 @@ export type LintResult = ESLint.LintResult | TemplateLintResult;
 export type LintMessage = Linter.LintMessage | TemplateLintMessage;
 
 // This type is deprecated, but is still included here for backwards compatibility.
+/**
+ * Represents the path to the todo file.
+ *
+ * @deprecated This type is deprecated in favor of the more descriptive TodoFileHash.
+ * @example
+ * 42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839
+ */
 export type FilePath = string;
+
+/**
+ * Represents the hashed filePath of the todos, which is a directory that contains todo files.
+ *
+ * @example
+ * 42b8532cff6da75c5e5895a6f33522bf37418d0c
+ */
+export type TodoFilePathHash = string;
+
+/**
+ * Represents the path to the todo file.
+ *
+ * @example
+ * 42b8532cff6da75c5e5895a6f33522bf37418d0c/6e3be839
+ */
 export type TodoFileHash = string;
+
+export type TodoBatches = {
+  add: Map<TodoFileHash, TodoData>;
+  expired: Map<TodoFileHash, TodoData>;
+  stable: Map<TodoFileHash, TodoData>;
+  remove: Set<TodoFileHash>;
+};
 export interface TodoData {
   engine: 'eslint' | 'ember-template-lint';
   filePath: string;
   ruleId: string;
   line: number;
   column: number;
+  source?: string;
   createdDate: number;
   warnDate?: number;
   errorDate?: number;
@@ -50,7 +80,7 @@ export type LintTodoPackageJson = PackageJson & {
   lintTodo?: TodoConfig | TodoConfigByEngine;
 };
 
-export type TodoBatchCounts = [number, number];
+export type TodoBatchCounts = [add: number, remove: number, stable: number, expired: number];
 
 export type DaysToDecay = {
   warn?: number;


### PR DESCRIPTION
Implements #246 and supersedes #236.

This change adds expanded matching capability on top of the existing exact matching. To disambiguate, the following are differences between the types of matchers:

**Exact match**

Matches on `engine`, `ruleID`, `line`, and `column`.

**Fuzzy match**

Matches on `engine`, `ruleID`, `source`

This enables a looser type of matching for situations when you have edits to a file, and an associated generated todo. Previously, due to the fact that we would always attempt an exact match, if edits occurred that modified the associated line and/or column, we would consider that an expired todo. Now, this affords us more allowance in how we're matching todos, which translates into the user requiring less todo maintenance. 

**Important Notes:**
- we've removed all async APIs in favor of sync. This was reduce the overall support surface area, and will allow us to use the sync APIs in both a sync and async consumption scenario.
- fuzzy matching functionality will not be enabled until both #253 and #254 are implemented