### PR TITLE
Adds missing export to public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { buildTodoData, buildTodoDatum } from './builders';
 export {
   applyTodoChanges,
   ensureTodoStorageDir,
+  getTodoBatches,
   getTodoStorageDirPath,
   readTodos,
   readTodosForFilePath,


### PR DESCRIPTION
I seem to have deleted the public export of `getTodoBatches`. This PR adds it back.