### PR TITLE
Converts the remove Set back to a Map, which is required for consumers

### DIFF
--- a/__tests__/io-test.ts
+++ b/__tests__/io-test.ts
@@ -339,13 +339,13 @@ describe('io', () => {
       });
 
       expect(counts).toMatchInlineSnapshot(`
-              Object {
-                "add": Map {},
-                "expired": Map {},
-                "remove": Set {},
-                "stable": Map {},
-              }
-          `);
+        Object {
+          "add": Map {},
+          "expired": Map {},
+          "remove": Map {},
+          "stable": Map {},
+        }
+      `);
     });
 
     it('creates items to add', async () => {

--- a/src/io.ts
+++ b/src/io.ts
@@ -215,7 +215,7 @@ export function getTodoBatches(
 export function applyTodoChanges(
   todoStorageDir: string,
   add: Map<TodoFileHash, TodoDataV2>,
-  remove: Set<TodoFileHash>
+  remove: Map<TodoFileHash, TodoDataV2>
 ): void {
   for (const [fileHash, todoDatum] of add) {
     const { dir } = posix.parse(fileHash);
@@ -224,7 +224,7 @@ export function applyTodoChanges(
     writeJsonSync(posix.join(todoStorageDir, `${fileHash}.json`), todoDatum);
   }
 
-  for (const fileHash of remove) {
+  for (const [fileHash] of remove) {
     const { dir } = posix.parse(fileHash);
     const todoDir = posix.join(todoStorageDir, dir);
 

--- a/src/todo-batch-generator.ts
+++ b/src/todo-batch-generator.ts
@@ -65,7 +65,7 @@ export default class TodoBatchGenerator {
     const add = new Map<TodoFileHash, TodoDataV2>();
     const expired = new Map<TodoFileHash, TodoDataV2>();
     const stable = new Map<TodoFileHash, TodoDataV2>();
-    let remove = new Set<TodoFileHash>();
+    let remove = new Map<TodoFileHash, TodoDataV2>();
 
     const unmatched = buildTodoData(this.baseDir, lintResults, this.options?.todoConfig);
 
@@ -115,7 +115,7 @@ export default class TodoBatchGenerator {
     }
 
     for (const matcher of [...existingTodos.values()]) {
-      remove = new Set([...remove, ...matcher.unmatched(this.options?.shouldRemove)]);
+      remove = new Map([...remove, ...matcher.unmatched(this.options?.shouldRemove)]);
     }
 
     return {

--- a/src/todo-matcher.ts
+++ b/src/todo-matcher.ts
@@ -44,12 +44,16 @@ export default class TodoMatcher {
     this.unprocessed = new Set();
   }
 
-  unmatched(predicate: (todoDatum: TodoDataV2) => boolean = () => false): string[] {
-    return [...this.unprocessed]
-      .filter((todoDatum) => predicate(todoDatum))
-      .map((todoDatum: TodoDataV2) => {
-        return todoFilePathFor(todoDatum);
-      });
+  unmatched(
+    predicate: (todoDatum: TodoDataV2) => boolean = () => false
+  ): Map<TodoFilePathHash, TodoDataV2> {
+    return new Map(
+      [...this.unprocessed]
+        .filter((todoDatum) => predicate(todoDatum))
+        .map((todoDatum: TodoDataV2) => {
+          return [todoFilePathFor(todoDatum), todoDatum];
+        })
+    );
   }
 
   add(todoDatum: TodoDataV2): void {

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -37,7 +37,7 @@ export type TodoBatches = {
   add: Map<TodoFileHash, TodoDataV2>;
   expired: Map<TodoFileHash, TodoDataV2>;
   stable: Map<TodoFileHash, TodoDataV2>;
-  remove: Set<TodoFileHash>;
+  remove: Map<TodoFileHash, TodoDataV2>;
 };
 
 export enum TodoFileFormat {


### PR DESCRIPTION
We previously used a `Map` not a `Set` in the `remove` batch. Recent updates moved this to a `Set`, since it appeared that we didn't actually need the associated `TodoData` for consumers. This was incorrect, and we actually use the data from the removed todo. 

This change puts it back, which feels nicer in terms of consistency between the batches.