### PR TITLE
Adds match agnostic lint result identity referencing

### DIFF
--- a/__tests__/__utils__/build-todo-data.ts
+++ b/__tests__/__utils__/build-todo-data.ts
@@ -34,6 +34,7 @@ export function buildMaybeTodos(
             ruleId: getRuleId(message),
             range,
             source: getSource(lintResult, message, range),
+            originalLintResult: message,
           },
           todoConfig
         );
@@ -72,6 +73,7 @@ export function buildExistingTodos(
             ruleId: getRuleId(message),
             range,
             source: getSource(lintResult, message, range),
+            originalLintResult: message,
           },
           todoConfig
         );

--- a/__tests__/builders-test.ts
+++ b/__tests__/builders-test.ts
@@ -14,6 +14,7 @@ describe('builders', () => {
 
   describe('buildTodoDatum', () => {
     it('builds a todo from eslint result', () => {
+      const fakeLintResult = { fake: true };
       const todoDatum = buildTodoDatum(tmp, {
         engine: 'eslint',
         filePath: `${tmp}/app/controllers/settings.js`,
@@ -29,6 +30,7 @@ describe('builders', () => {
           },
         },
         source: '',
+        originalLintResult: fakeLintResult,
       });
 
       expect(todoDatum).toEqual(
@@ -46,11 +48,13 @@ describe('builders', () => {
               column: 35,
             },
           },
+          originalLintResult: fakeLintResult,
         })
       );
     });
 
     it('can build todo data from results with days to decay warn only', () => {
+      const fakeLintResult = { fake: true };
       const todoDatum = buildTodoDatum(
         tmp,
         {
@@ -68,6 +72,7 @@ describe('builders', () => {
             },
           },
           source: '',
+          originalLintResult: fakeLintResult,
         },
         {
           daysToDecay: { warn: 30 },
@@ -78,6 +83,7 @@ describe('builders', () => {
     });
 
     it('can build todo data from results with days to decay error only', () => {
+      const fakeLintResult = { fake: true };
       const todoDatum = buildTodoDatum(
         tmp,
         {
@@ -95,6 +101,7 @@ describe('builders', () => {
             },
           },
           source: '',
+          originalLintResult: fakeLintResult,
         },
         {
           daysToDecay: { error: 30 },
@@ -105,6 +112,7 @@ describe('builders', () => {
     });
 
     it('can build todo data from results with days to decay warn and error', () => {
+      const fakeLintResult = { fake: true };
       const todoDatum = buildTodoDatum(
         tmp,
         {
@@ -122,6 +130,7 @@ describe('builders', () => {
             },
           },
           source: '',
+          originalLintResult: fakeLintResult,
         },
         {
           daysToDecay: {
@@ -137,6 +146,7 @@ describe('builders', () => {
 
     it('can build todo data with a custom createdDate', () => {
       process.env.TODO_CREATED_DATE = new Date(2015, 1, 23).toJSON();
+      const fakeLintResult = { fake: true };
       const todoDatum = buildTodoDatum(
         tmp,
         {
@@ -154,6 +164,7 @@ describe('builders', () => {
             },
           },
           source: '',
+          originalLintResult: fakeLintResult,
         },
         {
           daysToDecay: { warn: 30 },
@@ -167,6 +178,7 @@ describe('builders', () => {
     it('can build todo data with the correct range and source', () => {
       process.env.TODO_CREATED_DATE = new Date(2015, 1, 23).toJSON();
 
+      const fakeLintResult = { fake: true };
       const todoData = buildTodoDatum(tmp, {
         engine: 'eslint',
         filePath: `${tmp}/app/components/foo.js`,
@@ -182,6 +194,7 @@ describe('builders', () => {
           },
         },
         source: 'foo',
+        originalLintResult: fakeLintResult,
       });
 
       expect(todoData).toMatchInlineSnapshot(`
@@ -190,6 +203,9 @@ describe('builders', () => {
           "engine": "eslint",
           "fileFormat": 2,
           "filePath": "app/components/foo.js",
+          "originalLintResult": Object {
+            "fake": true,
+          },
           "range": Object {
             "end": Object {
               "column": 12,

--- a/src/todo-batch-generator.ts
+++ b/src/todo-batch-generator.ts
@@ -3,6 +3,15 @@ import { todoDirFor, todoFilePathFor } from './io';
 import TodoMatcher from './todo-matcher';
 import { TodoBatches, TodoDataV2, TodoFileHash, TodoFilePathHash, WriteTodoOptions } from './types';
 
+function copyLintResult(todoDatum: TodoDataV2, unmatchedTodoData: TodoDataV2) {
+  // this is a key transfer of information that allows us to match the identify
+  // of the original lint result to the todo data. This is important as it allows
+  // us to subsequently modify the severity of the original lint result. This is
+  // only required for todo data that is generated for the stable batch, as those
+  // are the only ones that are use to match back to the original lint result.
+  todoDatum.originalLintResult = unmatchedTodoData.originalLintResult;
+}
+
 /**
  * Creates todo batches based on lint results.
  */
@@ -72,6 +81,7 @@ export default class TodoBatchGenerator {
           if (isExpired(todoDatum.errorDate) && this.options?.shouldRemove?.(todoDatum)) {
             expired.set(todoFilePath, todoDatum);
           } else {
+            copyLintResult(todoDatum, unmatchedTodoData);
             stable.set(todoFilePath, todoDatum);
           }
 
@@ -93,6 +103,7 @@ export default class TodoBatchGenerator {
           if (isExpired(todoDatum.errorDate) && this.options?.shouldRemove?.(todoDatum)) {
             expired.set(todoFilePath, todoDatum);
           } else {
+            copyLintResult(todoDatum, unmatchedTodoData);
             stable.set(todoFilePath, todoDatum);
           }
         } else {

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -13,6 +13,7 @@ export interface GenericLintData {
   ruleId: string;
   range: Range;
   source: string;
+  originalLintResult: any;
 }
 
 // This type is deprecated, but is still included here for backwards compatibility.
@@ -76,6 +77,7 @@ export interface TodoDataV2 {
   source: string;
   warnDate?: number;
   errorDate?: number;
+  originalLintResult?: any;
 }
 
 export type TodoData = TodoDataV1 | TodoDataV2;


### PR DESCRIPTION
With the advent of fuzzy matching, referencing back to the original lint result was not possible using the [existing](https://github.com/ember-template-lint/ember-template-lint/blob/8a0cde77fbaf2d3ba2f0114e168b414290b3d2c6/lib/-private/todo-handler.js#L73-L79) [logic](https://github.com/scalvert/eslint-formatter-todo/blob/4054d19d830a8bff0ace29ab0ecd6c7d7a341214/src/formatter.ts#L80-L86) for identifying. We needed a way to associate the todo itself with the original lint result, thus providing a deterministic way of finding that lint result in order to mutate the severity, which is the crux of the todo functionality.

This PR adds a new mechanism whereby the consumers pass the lint result identity in when building the todo datum. This allows for referencing the lint result when processing the stable batch, which is the batch targeted to have its severity mutated.

This change has been tested and confirmed to work in both current consumers: [eslint](https://github.com/scalvert/eslint-formatter-todo) and [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint).