### PR TITLE
Change return value of writeTodos to object

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -116,7 +116,12 @@ export function writeTodos(
 
   applyTodoChanges(todoStorageDir, add, remove);
 
-  return [add.size, remove.size, stable.size, expired.size];
+  return {
+    addedCount: add.size,
+    removedCount: remove.size,
+    stableCount: stable.size,
+    expiredCount: expired.size,
+  };
 }
 
 /**

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -100,7 +100,12 @@ export type LintTodoPackageJson = PackageJson & {
   lintTodo?: TodoConfig | TodoConfigByEngine;
 };
 
-export type TodoBatchCounts = [add: number, remove: number, stable: number, expired: number];
+export type TodoBatchCounts = {
+  addedCount: number;
+  removedCount: number;
+  stableCount: number;
+  expiredCount: number;
+};
 
 export type DaysToDecay = {
   warn?: number;


### PR DESCRIPTION
This is the last breaking API change of the v10 release. This changes the `TodoBatchCounts` type to return an object with distinctly named properties instead of a tuple of numbers. This adds clarity to the API, and removes the need to return into an unreadable array destructure. 

```ts
export type TodoBatchCounts = {
  addedCount: number;
  removedCount: number;
  stableCount: number;
  expiredCount: number;
};
```