### PR TITLE
[WIP] PoC: Serialize todos as git notes

### DIFF
--- a/__tests__/git-utils-test.ts
+++ b/__tests__/git-utils-test.ts
@@ -1,0 +1,18 @@
+import { showNotes, addNotes } from "../src";
+import { buildMaybeTodosFromFixture } from "./__utils__/build-todo-data";
+import { createTmpDir } from "./__utils__/tmp-dir";
+import { spawnSync } from "child_process";
+
+describe('git-utils', () => {
+  it('creates new notes for HEAD', () => {
+    const tmp = createTmpDir();
+    const todos = buildMaybeTodosFromFixture(tmp, 'eslint-with-errors');
+    spawnSync('git init && git commit --allow-empty -mExample', { shell: true, cwd: tmp });
+
+    addNotes(todos, { cwd: tmp });
+
+    const notes = showNotes({ cwd: tmp });
+
+    expect(notes).toEqual(todos);
+  });
+});

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from 'child_process';
+import { TodoDataV2 } from './types';
+
+export function showNotes({ cwd = '.' }: { cwd: string }): Set<TodoDataV2> {
+  const { stdout, stderr, error } = spawnSync('git notes', ['show'], { shell: true, encoding: 'utf-8', cwd });
+
+  if (stderr || error) {
+    console.warn(stderr || error);
+    return new Set();
+  }
+
+  return new Set(JSON.parse(stdout));
+}
+
+export function addNotes(todos: Set<TodoDataV2>, { cwd }: { cwd: string }): void {
+  const message = [...todos].map((todo) => JSON.stringify(todo));
+
+  const { stderr, error } = spawnSync('git notes', ['add', '-f', '-m', JSON.stringify(message)], {
+    shell: true,
+    cwd,
+    encoding: 'utf-8',
+  });
+
+  if (stderr || error) {
+    console.warn(stderr || error);
+  }
+}

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -1,8 +1,14 @@
 import { spawnSync } from 'child_process';
 import { TodoDataV2 } from './types';
 
+const NOTES_REF = 'todos';
+
 export function showNotes({ cwd = '.' }: { cwd: string }): Set<TodoDataV2> {
-  const { stdout, stderr, error } = spawnSync('git notes', ['show'], { shell: true, encoding: 'utf-8', cwd });
+  const { stdout, stderr, error } = spawnSync('git notes', ['--ref', NOTES_REF, 'show'], {
+    shell: true,
+    encoding: 'utf-8',
+    cwd,
+  });
 
   if (stderr || error) {
     console.warn(stderr || error);
@@ -15,7 +21,7 @@ export function showNotes({ cwd = '.' }: { cwd: string }): Set<TodoDataV2> {
 export function addNotes(todos: Set<TodoDataV2>, { cwd }: { cwd: string }): void {
   const message = [...todos].map((todo) => JSON.stringify(todo));
 
-  const { stderr, error } = spawnSync('git notes', ['add', '-f', '-m', JSON.stringify(message)], {
+  const { stderr, error } = spawnSync('git notes', ['--ref', NOTES_REF, 'add', '-f', '-m', JSON.stringify(message)], {
     shell: true,
     cwd,
     encoding: 'utf-8',

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,6 @@ export {
 export { getTodoConfig, validateConfig } from './todo-config';
 export { getSeverity } from './get-severity';
 export { differenceInDays, format, getDatePart, isExpired } from './date-utils';
+export { showNotes, addNotes } from './git-utils';
 
 export * from './types';


### PR DESCRIPTION
## WIP - Do Not Merge

- Draft PoC to address #285 

## Notes

- git notes are not cloned/pulled/pushed automatically. this means that either the user has to manually manage the notes refs, which is probably a non-starter, or else the utils would manage it through installing git hooks or explicit `exec` calls. The latter 2 options may be unexpected side-effects for a broader user-base, but could be messaged when installing the utils.
- notes show up in log messages, and don't appear to be truncated reasonably. To make the log easier to read and obscure todos, we can use a ref to `refs/notes/todos` instead of the default `refs/notes/commits`.
- i don't think git itself imposes a size limit, though GitHub specifies 100MB max file size, which presumably would apply to the notes object.